### PR TITLE
docs: frontend & backend audit — bugs, error handling, UX, simplification

### DIFF
--- a/docs/AUDIT-2026-07.md
+++ b/docs/AUDIT-2026-07.md
@@ -1,0 +1,160 @@
+# Frontend & Backend Audit — July 2026
+
+Scope: full read-through of `apps/backend` (Kotlin/Spring) and `apps/frontend` (Next.js), plus the e2e suite, migrations, and configs. Findings are grouped by category and ordered by severity. File references point at the code as of `b790ecb`.
+
+Overall the codebase is in good shape — clean hexagonal backend with a result4k error channel, broad unit/scenario/e2e test coverage, and accessible, well-factored UI components. The findings below are the gaps.
+
+---
+
+## 1. Bugs
+
+### 1.1 Domain events are likely never delivered — no live updates, no metrics (Critical)
+
+`GameService` publishes events (`GameStateChangedEvent`, `ScoreSubmittedEvent`, …) inside `.peek { }` **after** `gameRepository.save()` returns (`service/GameService.kt:83`, `:119`, etc.). No service method is `@Transactional` (there is not a single `@Transactional` in main source), so the only transaction is the one inside Spring Data's `save()` — and it has already committed by the time `publishEvent` runs.
+
+Every listener in `events/GameEventListeners.kt` is `@TransactionalEventListener(phase = AFTER_COMMIT)`. With the default `fallbackExecution = false`, Spring **silently discards** events published outside an active transaction. Consequences:
+
+- STOMP broadcasts never fire → the scoreboard never live-updates, players never see event notifications (`EventNotificationOverlay`), and non-hosts never see the celebration screen without a manual refresh.
+- All `pubgolf.*` Prometheus counters stay at zero → the Grafana dashboard is empty.
+
+Supporting evidence: no backend test asserts `GameStateBroadcasterFake.broadcastedGames`, and the one e2e test that would observe a live update (`e2e/tests/full-game-flow.spec.ts:44`) does `page.reload()` instead.
+
+**Fix:** annotate the mutating `GameService`/`PubRouteService` methods with `@Transactional`. This also fixes atomicity (see 1.2). Verify with a two-browser e2e that asserts a score appears *without* reload, and by checking `/actuator/prometheus` after creating a game.
+
+### 1.2 Read–modify–write races lose data (Critical)
+
+Every mutation loads the whole `Game` aggregate, copies it, and re-saves the full object graph. There is no `@Version` optimistic locking on any entity and no surrounding transaction:
+
+- **Concurrent joins can delete players.** `GameEntity.players` is `@OneToMany(orphanRemoval = true)` (`models/Entity.kt:39`). If two players join at once, the save built from the stale snapshot doesn't contain the other player → Hibernate orphan-deletes their row.
+- **Concurrent score submissions can revert other players' scores.** Each save rewrites *all* players' score rows from its snapshot, so a save carrying a stale copy of another player's scores overwrites their newer value.
+
+This is the app's core usage pattern — a group of phones mutating one game simultaneously.
+
+**Fix:** add `@Version` to `GameEntity` (retry on `OptimisticLockException`), and/or stop rewriting the whole aggregate — e.g. `submitScore` should update one score row, `joinGame` should insert one player row.
+
+### 1.3 `useOptimisticGameState` is dead code, and its reconciliation can't work (High)
+
+`app/game/page.tsx` only consumes `{ gameState, cellStates }`; `addOptimisticUpdate` / `confirmUpdate` / `rollbackUpdate` are never called anywhere (score submission happens on a separate page and redirects). The 270-line hook is pass-through dead weight and `cellStates` is always empty.
+
+If it were wired in, it still misbehaves: reconciliation treats `committedScore === null` as "not yet committed" (`hooks/useOptimisticGameState.ts:84`), but the backend never returns null — unplayed holes are `0`. Any broadcast arriving before your own submission lands would spuriously roll back your pending cell with a "Score adjusted by server" toast.
+
+**Fix:** either wire it into the submit flow properly (and reconcile using a sentinel that actually exists) or delete the hook.
+
+### 1.4 Game-code collisions return HTTP 500 (High)
+
+`GameCode.random()` has a space of 9 golf terms × 1000 = **9,000 codes** (`models/Types.kt:13`); `games.code` is UNIQUE and games are never purged. Birthday math: ~50% chance of a collision once ~112 games exist. A collision surfaces as `PersistenceFailure` → 500 with a raw SQLite constraint message.
+
+**Fix:** retry generation on duplicate (and consider widening the space / recycling completed games).
+
+### 1.5 Randomise ("wildcard") hole selection is fragile (Medium)
+
+`GameService.randomiseHole` (`service/GameService.kt:308`):
+
+- Picks "most recently scored hole + 1" by timestamp. If a player *edits an earlier hole* (the UI encourages this — "tap any played hole to edit"), that hole becomes most recent and the wildcard is assigned to an already-played hole.
+- The `maxByOrNull == null` branch is unreachable (the map always has 9 entries) and its failure message ("No scores found") is mapped to the 409 "already used" bucket.
+- A player whose latest hole is 9 gets `RandomiseAlreadyUsedFailure("No more holes left")`, which the UI renders as "You have already used your spin for this game!" — wrong message.
+
+**Fix:** derive the target hole from "first unplayed hole" (same rule the frontend uses), and give "no holes left" its own failure type/message.
+
+### 1.6 `PATCH /games/{code}` ignores the request body (Medium)
+
+`updateGameStatus` never reads `UpdateGameStatusRequest.status` — `{"status": "ACTIVE"}` completes the game. Validate the requested transition (`controller/GameController.kt:484`).
+
+### 1.7 Nominatim adapter: cross-request race + global serialization (Medium)
+
+`NominatimPlaceSearchAdapter.search` (`adapter/geocoding/NominatimPlaceSearchAdapter.kt:50`):
+
+- The `finally` block does `clientQueues.remove(clientIdentifier)` — this removes the *newer* query registered by the same client's next request. Request B then reads `null != query` and returns an **empty result for a valid search** ("No results found" in the UI).
+- The semaphore is held across `Thread.sleep(1000)` + the HTTP call, so every search in the whole system queues behind a ≥1s critical section on servlet threads. Two or three hosts building routes at once will find search unusably slow.
+
+**Fix:** replace with a rate limiter that doesn't hold a servlet thread (or at minimum key the "superseded" map by request, not client, and cap wait time).
+
+### 1.8 `RestTemplate` has no timeouts (Medium)
+
+`RestTemplateConfig` returns a bare `RestTemplate()` — infinite connect/read timeouts. A hung OSRM call blocks `setPubs` indefinitely; a hung Nominatim call holds the search semaphore forever, wedging place search for everyone. The frontend times out at 15s and retries, stacking more stuck threads.
+
+**Fix:** set connect/read timeouts (a few seconds) on the shared `RestTemplate`.
+
+### 1.9 Unplayed holes render as "0", and 0 is a legal score (Medium)
+
+Backend uses score `0` as the "not played" sentinel, and `Leaderboard`'s `HoleStrip` renders `{score ?? '–'}` — the null branch never fires, so unplayed holes show a faint **0** instead of "–" (`components/Leaderboard.tsx:65`). Meanwhile the submit Counter allows -10…10, so a deliberate 0 (or negative total that passes through 0) is indistinguishable from "unplayed" and un-marks the hole.
+
+**Fix:** render `hasPlayedHole(score) ? score : '–'`; longer-term, use `null`/absent rather than 0 as the sentinel over the wire.
+
+### 1.10 Ranking uses raw totals; display uses par-relative (Medium)
+
+Sorting, rank, and `CelebrationScreen` winners all use `totalScore`, where unplayed holes count 0 — a player who logged fewer holes ranks above one who played more, and skipping holes is a winning strategy at "End Game" time. But the number *displayed* per row is par-relative over played holes only, so the order can look wrong against the numbers shown.
+
+**Fix:** decide one metric (par-relative of played holes is the fairer one) and use it for sort, rank, and winners.
+
+### 1.11 Pub search viewbox is hard-bounded (Low)
+
+Once the first pub is chosen, `bounded=1` restricts all subsequent searches to a ~±5 km box around pub 1 — pubs outside silently return "No results found" (`NominatimPlaceSearchAdapter.buildUrl`). Use the viewbox as a bias (drop `bounded=1`) or bias around the last-added pub.
+
+### 1.12 `PubEntity.toDomain` maps `PubId` from the game id (Low)
+
+Every pub's `id` is the game's UUID (`models/Domain.kt:332`). Harmless today because the id is unused — which suggests deleting `PubId` entirely (the real key is `(game_id, hole)`).
+
+---
+
+## 2. Error-handling gaps
+
+### 2.1 Backend
+
+- **Non-idempotent POSTs are retried by the frontend** (`lib/api.ts:65`): `createGame`, `joinGame`, `submitScore`, `spinWheel` all go through `fetchWithRetry`. A timeout after the server actually committed → duplicate game, spurious "player already exists", or a consumed wildcard whose result the user never sees. Restrict retry to GETs, or make these endpoints idempotent (idempotency key).
+- **Malformed JSON / type mismatches bypass `ErrorResponse`**: `ValidationExceptionHandler` only covers `MethodArgumentNotValidException` and `ServletRequestBindingException`. `HttpMessageNotReadableException` (bad JSON), `MethodArgumentTypeMismatchException`, and `HandlerMethodValidationException` (the `@Size` on `PlacesController.search`'s query param) all fall through to Spring's default error body — clients relying on `{message}` get a different shape.
+- **`PersistenceFailure` leaks internals**: `resolveFailure`'s else-branch returns the raw exception message (SQL/constraint text) in the 500 body (`repository/GameRepositoryAdapter.kt:34` → `GameController.kt:794`).
+- **Log levels**: every failure — including routine 404s and 409s — is logged at ERROR (`GameController.kt:779`), and genuine 500s are logged *without* the stack trace. Invert that.
+- **`setPubsForGame` is non-atomic and unrecoverable**: pubs are saved, then the game (with route geometry) is saved separately; a failure in between leaves pubs half-set, and `PubsAlreadySetFailure` then blocks any retry forever. There is also no endpoint to edit/replace a route. Make it one transaction and consider allowing overwrite by the host.
+- `/games/{code}/pubs` and `/games/{code}/route` lack the `@ApiResponses` documentation every other endpoint has (the approved OpenAPI spec is silently thinner there).
+
+### 2.2 Frontend
+
+- **No reconnect resync**: on STOMP reconnect the client re-subscribes but never refetches, so everything broadcast while offline is lost. Combined with no `visibilitychange`/focus refetch and no polling fallback, a phone that locks for ten minutes shows a stale board until the *next* broadcast.
+- **Misleading disconnect banner**: `MAX_RECONNECT_ATTEMPTS` only controls when the "disconnected — refresh to reconnect" banner shows; stompjs actually keeps reconnecting forever (`reconnectDelay: 5000`), so the banner is often wrong in both directions (`hooks/useGameWebSocket.ts:70`).
+- **Raw backend messages shown to users**: e.g. ``Player `Big Dave` already exists for game `PAR780`.`` with backticks/jargon, or ``Player `<uuid>` does not belong to game …``. Map known statuses to friendly copy.
+- **Unencoded path interpolation**: `gameCode` (user-typed) is interpolated into URL paths without `encodeURIComponent` throughout `lib/api.ts` — codes containing `/`, `#`, or spaces produce confusing failures.
+
+---
+
+## 3. User experience
+
+- **No session recovery.** Identity is only `localStorage`; clear it (or switch phones) and you can never rejoin as yourself — joining with the same name is rejected. The home page also doesn't offer "Resume your round" even when a session exists. Consider a rejoin flow (e.g. re-claim by name with confirmation) and a resume banner.
+- **The route builder is a dead end for hosts who skip it.** `/game/route` is only reachable via the create-game toggle; "Skip for now" is permanent because nothing links back and the backend forbids setting pubs twice. Add a "Set up route" entry on the host panel while no route exists.
+- **`/game/route` has no host guard** — any player can build all 9 pubs and only learns at save time (403). Check `hostPlayerId` up front like the host panel does.
+- **Host panel clobbers the stored session**: `setGameSession(gameCode, playerId ?? '', '')` overwrites `playerName` with `''` and can store an empty `playerId` (`app/game/[code]/host/page.tsx:73`). (Stored `playerName` is never read anywhere — see 4.)
+- **Wildcard odds are misrepresented**: the slot machine renders options unweighted while the server draw is weighted (`Outcomes.weight`), so perceived odds ≠ real odds. Cosmetic, but easy to pass `optionSize` through.
+- **Leaderboard tie ranking is dense** (1, 1, 2) rather than standard competition ranking (1, 1, 3) (`components/Leaderboard.tsx:32`). Pick one deliberately.
+- **Search requires a button press per query** with a global ≥1s server-side queue behind it; with several concurrent users it feels broken. At minimum surface a "searching may take a few seconds" state; ideally fix 1.7/1.8 first.
+
+---
+
+## 4. Simplification opportunities
+
+**Backend**
+
+- `joinGame` returns `game.copy(players = listOf(player))` so the controller can read `players[0]` — return the new `Player` (or a dedicated result) instead of a fake `Game` (`service/GameService.kt:86`).
+- `GameController` is ~800 lines, mostly repeated `@ApiResponses` blocks — extract shared meta-annotations (e.g. `@StandardErrorResponses`) or a springdoc `OperationCustomizer`.
+- `routeGeometry` is hand-serialized to `"LineString:lng,lat;lng,lat"` and hand-parsed back (`models/Domain.kt:253`, `:222`) — store JSON via Jackson in the TEXT column; malformed strings currently just null the route silently.
+- `RandomiseResult.outcomes` is never used by the response mapping — drop it.
+- `GameEvent` list is static; `GET /games/{code}/events` doesn't need a game lookup (or belongs under `/config` with the other static endpoints).
+- The unreachable branch in `randomiseHole` and the timestamp-set heuristic go away naturally with the 1.5 fix.
+
+**Frontend**
+
+- Delete or wire in `useOptimisticGameState` (1.3); delete unused `GameCodeDisplay` component; stop storing `playerName` (written, never read) or start using it.
+- `lib/api.ts`: every function repeats `timedFetch` + headers + `handleResponse` — collapse into one `request<T>(path, init)` helper; also share the localStorage keys with `useLocalStorage` instead of re-hardcoding them in the 401 handler.
+- `WheelOption`/`WheelOptionsResponse` are declared in both `lib/api.ts` and `app/randomise/page.tsx`; `DEFAULT_PARS` duplicates the backend routes config (acceptable as a fallback, but worth a comment tying them together).
+
+---
+
+## Suggested priority
+
+1. `@Transactional` on service mutations + verify broadcasts/metrics actually fire (1.1)
+2. Optimistic locking / narrower writes for concurrent mutations (1.2)
+3. Stop retrying non-idempotent POSTs (2.1)
+4. Game-code collision retry (1.4)
+5. RestTemplate timeouts + Nominatim race (1.7, 1.8)
+6. Score sentinel & ranking consistency (1.9, 1.10)
+7. Session recovery & route-builder dead end (UX)
+8. The simplification list, opportunistically


### PR DESCRIPTION
Adds `docs/AUDIT-2026-07.md` — a full read-through audit of `apps/backend` and `apps/frontend` covering bugs, gaps in error handling, poor UX, and simplification opportunities. No code changes; the document is the deliverable.

## Headline findings

1. **Domain events are likely never delivered.** `GameService` publishes events after `save()` returns and no service method is `@Transactional`, so the `@TransactionalEventListener(AFTER_COMMIT)` listeners silently discard every event — meaning no live STOMP scoreboard updates, no event notifications, and Prometheus game counters stuck at zero. (Notably, the one e2e test that would observe a live update calls `page.reload()` instead.)
2. **Lost-update races on the Game aggregate.** Whole-aggregate read-modify-write with `orphanRemoval = true` and no `@Version`: concurrent joins can delete a just-joined player; concurrent score submissions can revert other players' scores.
3. **Frontend retries non-idempotent POSTs** (`createGame`, `joinGame`, `submitScore`, `spinWheel`) — a timeout after server-side success duplicates games or consumes the wildcard invisibly.
4. **Game-code space is 9,000 codes** with a UNIQUE constraint and no cleanup — collisions surface as HTTP 500 with raw SQLite error text.
5. `useOptimisticGameState` is dead code (its write API is never called), and its reconciliation logic can't work against a backend that never returns null scores.

The document also covers: `PATCH /games/{code}` ignoring its request body, the Nominatim adapter's cross-request race + global 1s serialization, missing `RestTemplate` timeouts, the score-0-as-unplayed sentinel clash, raw-total vs par-relative ranking inconsistency, missing session recovery/rejoin, the route-builder dead end, error-shape gaps, and a simplification list for both apps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KCj2mQtrQ42GJnEVNQhJcL

---
_Generated by [Claude Code](https://claude.ai/code/session_01KCj2mQtrQ42GJnEVNQhJcL)_