### PR TITLE
Fix 201 response parsing on route creation and truncate pub name in hole log

### DIFF
--- a/apps/frontend/app/submit-score/page.tsx
+++ b/apps/frontend/app/submit-score/page.tsx
@@ -110,7 +110,7 @@ export default function SubmitScorePage() {
 
   const selectedPenalty = penaltyOptions.find((p) => p.type === penaltyType);
   const currentPar = pars[hole - 1];
-  const currentPubName = pubs.find((pub) => pub.hole === hole)?.name;
+  const currentPubName = pubs.find((pub) => pub.hole === hole)?.name?.split(',')[0];
   const displayedScore = penaltyType && selectedPenalty ? selectedPenalty.points : score;
 
   const parReadout = () => {

--- a/apps/frontend/lib/api.test.ts
+++ b/apps/frontend/lib/api.test.ts
@@ -4,6 +4,7 @@ import {
   joinGame,
   getGameState,
   submitScore,
+  setPubs,
   getRandomiseOptions,
   spinWheel,
   ApiError,
@@ -161,6 +162,16 @@ describe('API functions', () => {
       mockFetch.mockResolvedValueOnce(new Response(null, { status: 204 }));
 
       const result = await submitScore('ABCD', 'player-123', 1, 2);
+
+      expect(result).toBeUndefined();
+    });
+  });
+
+  describe('setPubs', () => {
+    test('should handle 201 response with empty body', async () => {
+      mockFetch.mockResolvedValueOnce(new Response(null, { status: 201 }));
+
+      const result = await setPubs('ABCD', 'player-123', []);
 
       expect(result).toBeUndefined();
     });

--- a/apps/frontend/lib/api.ts
+++ b/apps/frontend/lib/api.ts
@@ -60,7 +60,12 @@ async function handleResponse<T>(response: Response): Promise<T> {
     return undefined as T;
   }
 
-  return response.json();
+  const text = await response.text();
+  if (!text) {
+    return undefined as T;
+  }
+
+  return JSON.parse(text);
 }
 
 function statusMessage(status: number, fallback: string): string {


### PR DESCRIPTION
## Summary
- Fix `setPubs` (`PUT /games/{code}/pubs`), which returns HTTP 201 with an empty body. The frontend's `handleResponse` only special-cased 204 responses and called `response.json()` on everything else, so the empty 201 body threw a JSON parse error even though the request succeeded.
- Truncate the pub name shown on the hole scoring ("log your sip") screen at the first comma, since pub names can include an address/locality suffix after a comma.

## Test plan
- [x] `bun test` — all 391 tests pass, including a new regression test for `setPubs` handling a 201 with an empty body
- [x] `eslint` on changed files — clean


---
_Generated by [Claude Code](https://claude.ai/code/session_01VjRNQRnDmmuAeA6vjAPrGD)_