### PR TITLE
Add host-editable drinks and pars to the host panel

### DIFF
--- a/apps/backend/src/main/kotlin/uk/co/suskins/pubgolf/controller/GameController.kt
+++ b/apps/backend/src/main/kotlin/uk/co/suskins/pubgolf/controller/GameController.kt
@@ -48,6 +48,7 @@ import uk.co.suskins.pubgolf.models.GameNotFoundFailure
 import uk.co.suskins.pubgolf.models.GameRequest
 import uk.co.suskins.pubgolf.models.GameStateResponse
 import uk.co.suskins.pubgolf.models.GameStatus
+import uk.co.suskins.pubgolf.models.InvalidCourseFailure
 import uk.co.suskins.pubgolf.models.InvalidHostFailure
 import uk.co.suskins.pubgolf.models.InvalidPubCountFailure
 import uk.co.suskins.pubgolf.models.InvalidStatusTransitionFailure
@@ -68,8 +69,10 @@ import uk.co.suskins.pubgolf.models.RouteResponse
 import uk.co.suskins.pubgolf.models.ScoreRequest
 import uk.co.suskins.pubgolf.models.SetActiveEventRequest
 import uk.co.suskins.pubgolf.models.SetCustomActiveEventRequest
+import uk.co.suskins.pubgolf.models.SetHolesRequest
 import uk.co.suskins.pubgolf.models.SetPubsRequest
 import uk.co.suskins.pubgolf.models.UpdateGameStatusRequest
+import uk.co.suskins.pubgolf.models.toCourseHole
 import uk.co.suskins.pubgolf.models.toGameStateResponse
 import uk.co.suskins.pubgolf.models.toResponse
 import uk.co.suskins.pubgolf.service.GameService
@@ -368,6 +371,29 @@ class GameController(
                 resolveFailure(it)
             }.get()
 
+    @PutMapping("/{gameCode}/holes")
+    @SecurityRequirement(name = "PlayerIdHeader")
+    @ApiResponse(
+        responseCode = "200",
+        description = "Course set for the game (replaces any existing drinks and pars)",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = GameStateResponse::class))],
+    )
+    @StandardErrorResponses
+    fun setHoles(
+        @PathVariable("gameCode") gameCode: GameCode,
+        @RequestHeader(value = "PubGolf-Player-Id", required = false) playerIdHeader: String?,
+        @Valid @RequestBody request: SetHolesRequest,
+    ): ResponseEntity<*> =
+        parsePlayerIdHeader(playerIdHeader)
+            .flatMap { playerId ->
+                gameService
+                    .validatePlayerInGame(gameCode, playerId)
+                    .flatMap { gameService.setCourse(gameCode, playerId, request.holes.map { it.toCourseHole() }) }
+            }.map { it.toGameStateResponse() }
+            .map { ResponseEntity.status(OK).body(it) }
+            .mapFailure { resolveFailure(it) }
+            .get()
+
     @GetMapping("/{gameCode}/route")
     @ApiResponse(
         responseCode = "200",
@@ -425,6 +451,7 @@ class GameController(
                 is EventNotFoundFailure -> NOT_FOUND
                 is PlayerAlreadyExistsFailure -> BAD_REQUEST
                 is InvalidPubCountFailure -> BAD_REQUEST
+                is InvalidCourseFailure -> BAD_REQUEST
                 is InvalidStatusTransitionFailure -> BAD_REQUEST
                 is RandomiseAlreadyUsedFailure -> CONFLICT
                 is NoHolesLeftFailure -> CONFLICT

--- a/apps/backend/src/main/kotlin/uk/co/suskins/pubgolf/events/GameEventListeners.kt
+++ b/apps/backend/src/main/kotlin/uk/co/suskins/pubgolf/events/GameEventListeners.kt
@@ -71,4 +71,9 @@ class GameLoggingListener {
     fun onEventEnded(event: EventEndedEvent) {
         logger.info("Event ended for game ${event.gameCode.value}")
     }
+
+    @EventListener
+    fun onCourseUpdated(event: CourseUpdatedEvent) {
+        logger.info("Course updated for game ${event.gameCode.value} with routes ${event.routeNames}")
+    }
 }

--- a/apps/backend/src/main/kotlin/uk/co/suskins/pubgolf/events/GameEvents.kt
+++ b/apps/backend/src/main/kotlin/uk/co/suskins/pubgolf/events/GameEvents.kt
@@ -65,3 +65,9 @@ data class EventEndedEvent(
     override val gameCode: GameCode,
     override val timestamp: Instant = Instant.now(),
 ) : GameEvent
+
+data class CourseUpdatedEvent(
+    override val gameCode: GameCode,
+    val routeNames: List<String>,
+    override val timestamp: Instant = Instant.now(),
+) : GameEvent

--- a/apps/backend/src/main/kotlin/uk/co/suskins/pubgolf/models/DTO.kt
+++ b/apps/backend/src/main/kotlin/uk/co/suskins/pubgolf/models/DTO.kt
@@ -49,6 +49,8 @@ data class GameStateResponse(
     val hostPlayerId: PlayerId?,
     val players: List<PlayerResponse>,
     val activeEvent: ActiveEventResponse?,
+    // The game's own course: the host's customisation, or the default course if never edited.
+    val holes: List<HoleResponse>,
 )
 
 data class RandomiseResponse(
@@ -171,6 +173,23 @@ data class RouteGeometryResponse(
 data class RouteResponse(
     val pubs: List<PubLocationResponse>,
     val route: RouteGeometryResponse?,
+)
+
+data class CourseHoleDto(
+    @field:Min(value = 1, message = "Hole must be between 1 and 9")
+    @field:Max(value = 9, message = "Hole must be between 1 and 9")
+    val hole: Int,
+    @field:Min(value = 1, message = "Par must be between 1 and 10")
+    @field:Max(value = 10, message = "Par must be between 1 and 10")
+    val par: Int,
+    // Route name to drink. Key order sets the display order and must match across holes.
+    val drinks: Map<String, String>,
+)
+
+data class SetHolesRequest(
+    @field:Size(min = 9, max = 9, message = "Exactly 9 holes are required")
+    @field:Valid
+    val holes: List<CourseHoleDto>,
 )
 
 data class UpdateGameStatusRequest(

--- a/apps/backend/src/main/kotlin/uk/co/suskins/pubgolf/models/Domain.kt
+++ b/apps/backend/src/main/kotlin/uk/co/suskins/pubgolf/models/Domain.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import java.time.Instant
 
 private val routeGeometryMapper = jacksonObjectMapper()
+private val drinksMapper = jacksonObjectMapper()
 
 data class Game(
     val id: GameId,
@@ -14,9 +15,15 @@ data class Game(
     val activeEvent: ActiveEvent? = null,
     val pubs: List<Pub> = emptyList(),
     val routeGeometry: RouteGeometry? = null,
+    // Empty until the host customises the course; games then fall back to the default course.
+    val holes: List<CourseHole> = emptyList(),
     // Optimistic-lock version carried from the entity so stale saves are rejected; null until first persisted.
     val version: Long? = null,
-)
+) {
+    fun course(): List<CourseHole> = holes.ifEmpty { Routes.defaultCourse }
+
+    fun par(hole: Hole): Int = course().firstOrNull { it.hole == hole }?.par ?: Routes.par(hole)
+}
 
 data class Player(
     val id: PlayerId,
@@ -216,6 +223,10 @@ data class InvalidPubCountFailure(
     override val message: String,
 ) : PubGolfFailure
 
+data class InvalidCourseFailure(
+    override val message: String,
+) : PubGolfFailure
+
 data class InvalidHostFailure(
     override val message: String,
 ) : PubGolfFailure
@@ -258,8 +269,28 @@ data class RouteHole(
     val drinks: Map<String, String>,
 )
 
+// A hole on a game's own course: one par, and one drink per named route.
+// Iteration order of `drinks` is the order the routes are displayed in.
+data class CourseHole(
+    val hole: Hole,
+    val par: Int,
+    val drinks: Map<String, String>,
+)
+
+fun CourseHoleDto.toCourseHole(): CourseHole =
+    CourseHole(
+        hole = Hole(hole),
+        par = par,
+        drinks = drinks,
+    )
+
 object Routes {
     fun par(hole: Hole): Int = holes.first { it.hole == hole.value }.par
+
+    // Seeds a new game's editable course and answers /config/routes for visitors without a game.
+    val defaultCourse: List<CourseHole> by lazy {
+        holes.map { CourseHole(Hole(it.hole), it.par, it.drinks) }
+    }
 
     val holes: List<RouteHole> =
         listOf(
@@ -343,8 +374,20 @@ fun Game.toJpa(): GameEntity {
         gameEntity.addPub(pubEntity)
     }
 
+    holes.forEach { hole ->
+        gameEntity.addHole(hole.toJpa(gameEntity))
+    }
+
     return gameEntity
 }
+
+fun CourseHole.toJpa(gameEntity: GameEntity): GameHoleEntity =
+    GameHoleEntity(
+        id = GameHoleId(gameId = gameEntity.id, hole = hole.value),
+        game = gameEntity,
+        par = par,
+        drinks = drinksMapper.writeValueAsString(drinks),
+    )
 
 fun Pub.toJpa(gameEntity: GameEntity): PubEntity =
     PubEntity(
@@ -383,7 +426,7 @@ fun Game.toGameStateResponse(): GameStateResponse =
                         totalScore = player.scores.values.sumOf { it.score.value },
                         parRelative =
                             player.scores.entries.sumOf { (hole, score) ->
-                                score.score.value - Routes.par(hole)
+                                score.score.value - par(hole)
                             },
                         randomise =
                             player.randomise?.let {
@@ -401,4 +444,5 @@ fun Game.toGameStateResponse(): GameStateResponse =
                     ),
                 ),
         activeEvent = activeEvent?.toResponse(),
+        holes = course().map { HoleResponse(it.hole.value, it.par, it.drinks) },
     )

--- a/apps/backend/src/main/kotlin/uk/co/suskins/pubgolf/models/Entity.kt
+++ b/apps/backend/src/main/kotlin/uk/co/suskins/pubgolf/models/Entity.kt
@@ -56,6 +56,9 @@ data class GameEntity(
     @OneToMany(cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.EAGER)
     @JoinColumn(name = "game_id")
     val pubs: MutableList<PubEntity> = mutableListOf(),
+    @OneToMany(cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.EAGER)
+    @JoinColumn(name = "game_id")
+    val holes: MutableList<GameHoleEntity> = mutableListOf(),
 ) {
     fun addPlayer(playerEntity: PlayerEntity) {
         this.players.add(playerEntity)
@@ -63,6 +66,10 @@ data class GameEntity(
 
     fun addPub(pubEntity: PubEntity) {
         this.pubs.add(pubEntity)
+    }
+
+    fun addHole(gameHoleEntity: GameHoleEntity) {
+        this.holes.add(gameHoleEntity)
     }
 }
 
@@ -182,6 +189,40 @@ data class PubEntity(
     val longitude: Double,
 )
 
+@Embeddable
+data class GameHoleId(
+    @Column(name = "game_id")
+    val gameId: UUID = UUID.randomUUID(),
+    @Column(name = "hole")
+    val hole: Int = 0,
+) : Serializable
+
+@Entity
+@Table(name = "game_holes")
+data class GameHoleEntity(
+    @EmbeddedId
+    val id: GameHoleId,
+    @ManyToOne(fetch = FetchType.LAZY)
+    @MapsId("gameId")
+    @JoinColumn(name = "game_id", nullable = false)
+    val game: GameEntity,
+    @Column(name = "par", nullable = false)
+    val par: Int,
+    // JSON object of route name to drink; key order is the display order of the routes.
+    @Column(name = "drinks", nullable = false)
+    val drinks: String,
+)
+
+fun GameHoleEntity.toDomain(): CourseHole =
+    CourseHole(
+        hole = Hole(id.hole),
+        par = par,
+        drinks = parseDrinks(drinks),
+    )
+
+private fun parseDrinks(stored: String): Map<String, String> =
+    runCatching { drinksMapper.readValue<LinkedHashMap<String, String>>(stored) }.getOrDefault(emptyMap())
+
 fun GameEntity.toDomain(): Game =
     Game(
         id = GameId(id),
@@ -242,10 +283,15 @@ fun GameEntity.toDomain(): Game =
             pubs
                 .sortedBy { it.id.hole }
                 .map { it.toDomain() },
+        holes =
+            holes
+                .sortedBy { it.id.hole }
+                .map { it.toDomain() },
         routeGeometry = routeGeometry?.let { parseRouteGeometry(it) },
     )
 
 private val routeGeometryMapper = jacksonObjectMapper()
+private val drinksMapper = jacksonObjectMapper()
 
 // Stored as JSON; rows written before V9-era code used "LineString:lng,lat;lng,lat".
 private fun parseRouteGeometry(stored: String): RouteGeometry? =

--- a/apps/backend/src/main/kotlin/uk/co/suskins/pubgolf/service/GameService.kt
+++ b/apps/backend/src/main/kotlin/uk/co/suskins/pubgolf/service/GameService.kt
@@ -9,6 +9,7 @@ import dev.forkhandles.result4k.map
 import dev.forkhandles.result4k.peek
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
+import uk.co.suskins.pubgolf.events.CourseUpdatedEvent
 import uk.co.suskins.pubgolf.events.EventActivatedEvent
 import uk.co.suskins.pubgolf.events.EventEndedEvent
 import uk.co.suskins.pubgolf.events.GameCompletedEvent
@@ -20,6 +21,7 @@ import uk.co.suskins.pubgolf.events.ScoreSubmittedEvent
 import uk.co.suskins.pubgolf.models.ActiveEvent
 import uk.co.suskins.pubgolf.models.ActiveEventState
 import uk.co.suskins.pubgolf.models.ConcurrentModificationFailure
+import uk.co.suskins.pubgolf.models.CourseHole
 import uk.co.suskins.pubgolf.models.DuplicateGameCodeFailure
 import uk.co.suskins.pubgolf.models.EventAlreadyActiveFailure
 import uk.co.suskins.pubgolf.models.EventNotFoundFailure
@@ -31,6 +33,7 @@ import uk.co.suskins.pubgolf.models.GameEvent
 import uk.co.suskins.pubgolf.models.GameId
 import uk.co.suskins.pubgolf.models.GameStatus
 import uk.co.suskins.pubgolf.models.Hole
+import uk.co.suskins.pubgolf.models.InvalidCourseFailure
 import uk.co.suskins.pubgolf.models.JoinResult
 import uk.co.suskins.pubgolf.models.NoHolesLeftFailure
 import uk.co.suskins.pubgolf.models.NotHostPlayerFailure
@@ -51,6 +54,11 @@ import java.time.Instant
 
 private const val CREATE_GAME_ATTEMPTS = 5
 private const val CONCURRENT_MODIFICATION_ATTEMPTS = 3
+private const val MIN_PAR = 1
+private const val MAX_PAR = 10
+private const val MAX_ROUTES = 4
+private const val MAX_ROUTE_NAME_LENGTH = 40
+private const val MAX_DRINK_LENGTH = 100
 
 @Service
 class GameService(
@@ -297,6 +305,99 @@ class GameService(
                     }
                 }
         }
+
+    // Replaces the whole course. Pars feed par-relative ranking, so an edit mid-game
+    // re-ranks the leaderboard as soon as the new state is broadcast.
+    fun setCourse(
+        gameCode: GameCode,
+        playerId: PlayerId,
+        holes: List<CourseHole>,
+    ): Result<Game, PubGolfFailure> =
+        retryOnConcurrentModification {
+            validateCourse(holes)
+                .flatMap { gameRepository.findByCodeIgnoreCase(gameCode) }
+                .flatMap { isNotCompleted(it, "Cannot change the course of a completed game") }
+                .flatMap { isHost(it, playerId, "change drinks and pars") }
+                .flatMap { game ->
+                    val course = normaliseCourse(holes)
+                    gameRepository
+                        .save(game.copy(holes = course))
+                        .peek { updatedGame ->
+                            eventPublisher.publishEvent(CourseUpdatedEvent(updatedGame.code, routeNames(course)))
+                            eventPublisher.publishEvent(GameStateChangedEvent(updatedGame.code, updatedGame))
+                        }
+                }
+        }
+
+    private fun validateCourse(holes: List<CourseHole>): Result<List<CourseHole>, PubGolfFailure> {
+        val expectedHoles = (1..GameConstants.MAX_HOLES).map { Hole(it) }
+        if (holes.map { it.hole }.sortedBy { it.value } != expectedHoles) {
+            return Failure(InvalidCourseFailure("Each hole from 1 to ${GameConstants.MAX_HOLES} must be set exactly once"))
+        }
+        holes.firstOrNull { it.par < MIN_PAR || it.par > MAX_PAR }?.let {
+            return Failure(InvalidCourseFailure("Par for hole ${it.hole.value} must be between $MIN_PAR and $MAX_PAR"))
+        }
+
+        val routes = routeNames(holes)
+        if (routes.isEmpty() || routes.size > MAX_ROUTES) {
+            return Failure(InvalidCourseFailure("A course needs between 1 and $MAX_ROUTES routes"))
+        }
+        if (routes.any { it.isBlank() }) {
+            return Failure(InvalidCourseFailure("Route names must not be blank"))
+        }
+        routes.firstOrNull { it.trim().length > MAX_ROUTE_NAME_LENGTH }?.let {
+            return Failure(InvalidCourseFailure("Route name `$it` must be $MAX_ROUTE_NAME_LENGTH characters or fewer"))
+        }
+        if (routes.map { it.trim().lowercase() }.distinct().size != routes.size) {
+            return Failure(InvalidCourseFailure("Route names must be unique"))
+        }
+
+        val trimmedRoutes = routes.map { it.trim() }
+        val expectedRoutes = trimmedRoutes.toSet()
+        holes.forEach { hole ->
+            // Set comparison: a hole may list its routes in any order, and normaliseCourse
+            // then rewrites every hole into the order hole 1 declared.
+            val holeRoutes =
+                hole.drinks.keys
+                    .map { it.trim() }
+                    .toSet()
+            if (hole.drinks.size != trimmedRoutes.size || holeRoutes != expectedRoutes) {
+                return Failure(InvalidCourseFailure("Hole ${hole.hole.value} must have a drink for every route"))
+            }
+            hole.drinks.forEach { (route, drink) ->
+                if (drink.isBlank()) {
+                    return Failure(InvalidCourseFailure("Drink for hole ${hole.hole.value} on `$route` must not be blank"))
+                }
+                if (drink.trim().length > MAX_DRINK_LENGTH) {
+                    return Failure(
+                        InvalidCourseFailure("Drink for hole ${hole.hole.value} on `$route` must be $MAX_DRINK_LENGTH characters or fewer"),
+                    )
+                }
+            }
+        }
+
+        return Success(holes)
+    }
+
+    // Sorts by hole and trims names so stored key order is the display order for every hole.
+    private fun normaliseCourse(holes: List<CourseHole>): List<CourseHole> {
+        val routes = routeNames(holes).map { it.trim() }
+        return holes
+            .sortedBy { it.hole.value }
+            .map { hole ->
+                val trimmed = hole.drinks.entries.associate { (route, drink) -> route.trim() to drink.trim() }
+                hole.copy(drinks = routes.associateWith { trimmed.getValue(it) })
+            }
+    }
+
+    // Route order comes from the lowest-numbered hole; every hole is validated to match it.
+    private fun routeNames(holes: List<CourseHole>): List<String> =
+        holes
+            .minByOrNull { it.hole.value }
+            ?.drinks
+            ?.keys
+            ?.toList()
+            .orEmpty()
 
     private fun hasNoActiveEvent(game: Game): Result<Game, PubGolfFailure> =
         if (game.activeEvent != null) {

--- a/apps/backend/src/main/resources/db/migration/V10__game_holes.sql
+++ b/apps/backend/src/main/resources/db/migration/V10__game_holes.sql
@@ -1,0 +1,8 @@
+CREATE TABLE game_holes (
+    game_id BLOB NOT NULL,
+    hole INT NOT NULL,
+    par INT NOT NULL,
+    drinks TEXT NOT NULL,
+    PRIMARY KEY (game_id, hole),
+    CONSTRAINT fk_game_hole_game FOREIGN KEY (game_id) REFERENCES games(id) ON DELETE CASCADE
+);

--- a/apps/backend/src/test/kotlin/uk/co/suskins/pubgolf/repository/GameRepositoryContract.kt
+++ b/apps/backend/src/test/kotlin/uk/co/suskins/pubgolf/repository/GameRepositoryContract.kt
@@ -11,6 +11,7 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
 import org.springframework.test.context.ActiveProfiles
 import uk.co.suskins.pubgolf.models.ConcurrentModificationFailure
+import uk.co.suskins.pubgolf.models.CourseHole
 import uk.co.suskins.pubgolf.models.DuplicateGameCodeFailure
 import uk.co.suskins.pubgolf.models.Game
 import uk.co.suskins.pubgolf.models.GameCode
@@ -23,6 +24,7 @@ import uk.co.suskins.pubgolf.models.PenaltyType
 import uk.co.suskins.pubgolf.models.Player
 import uk.co.suskins.pubgolf.models.PlayerId
 import uk.co.suskins.pubgolf.models.PlayerName
+import uk.co.suskins.pubgolf.models.Routes
 import uk.co.suskins.pubgolf.models.Score
 import uk.co.suskins.pubgolf.service.hasPlayer
 import kotlin.test.Test
@@ -145,6 +147,51 @@ interface GameRepositoryContract {
             )
 
         assertTrue(result.failureOrNull() is DuplicateGameCodeFailure)
+    }
+
+    @Test
+    fun `can save and find a game with a custom course`() {
+        val course =
+            (1..9).map { hole ->
+                CourseHole(Hole(hole), hole % 4 + 1, linkedMapOf("Ale Trail" to "Ale $hole", "Spirit Run" to "Spirit $hole"))
+            }
+        val game =
+            Game(
+                id = GameId.random(),
+                code = GameCode("COURSE001"),
+                players = listOf(Player(PlayerId.random(), PlayerName("Ben"))),
+                holes = course,
+            )
+
+        val saved = gameRepository.save(game).valueOrNull()!!
+        assertThat(saved.holes, equalTo(course))
+
+        val found = gameRepository.findByCodeIgnoreCase(GameCode("COURSE001")).valueOrNull()!!
+        assertThat(found.holes, equalTo(course))
+        // Route order round-trips, because it drives the column order players see.
+        assertThat(
+            found.holes
+                .first()
+                .drinks.keys
+                .toList(),
+            equalTo(listOf("Ale Trail", "Spirit Run")),
+        )
+    }
+
+    @Test
+    fun `a game with no custom course falls back to the default course`() {
+        val game =
+            Game(
+                id = GameId.random(),
+                code = GameCode("COURSE002"),
+                players = listOf(Player(PlayerId.random(), PlayerName("Ben"))),
+            )
+
+        gameRepository.save(game)
+
+        val found = gameRepository.findByCodeIgnoreCase(GameCode("COURSE002")).valueOrNull()!!
+        assertTrue(found.holes.isEmpty())
+        assertThat(found.course(), equalTo(Routes.defaultCourse))
     }
 
     @Test

--- a/apps/backend/src/test/kotlin/uk/co/suskins/pubgolf/service/GameServiceTest.kt
+++ b/apps/backend/src/test/kotlin/uk/co/suskins/pubgolf/service/GameServiceTest.kt
@@ -12,20 +12,25 @@ import dev.forkhandles.result4k.valueOrNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.context.ApplicationEventPublisher
+import uk.co.suskins.pubgolf.events.CourseUpdatedEvent
 import uk.co.suskins.pubgolf.events.GameEventCaptor
+import uk.co.suskins.pubgolf.events.GameStateChangedEvent
 import uk.co.suskins.pubgolf.models.ActiveEvent
 import uk.co.suskins.pubgolf.models.ConcurrentModificationFailure
+import uk.co.suskins.pubgolf.models.CourseHole
 import uk.co.suskins.pubgolf.models.DuplicateGameCodeFailure
 import uk.co.suskins.pubgolf.models.EventAlreadyActiveFailure
 import uk.co.suskins.pubgolf.models.EventNotFoundFailure
 import uk.co.suskins.pubgolf.models.Game
 import uk.co.suskins.pubgolf.models.GameAlreadyCompletedFailure
 import uk.co.suskins.pubgolf.models.GameCode
+import uk.co.suskins.pubgolf.models.GameConstants
 import uk.co.suskins.pubgolf.models.GameEvent
 import uk.co.suskins.pubgolf.models.GameId
 import uk.co.suskins.pubgolf.models.GameNotFoundFailure
 import uk.co.suskins.pubgolf.models.GameStatus
 import uk.co.suskins.pubgolf.models.Hole
+import uk.co.suskins.pubgolf.models.InvalidCourseFailure
 import uk.co.suskins.pubgolf.models.NoHolesLeftFailure
 import uk.co.suskins.pubgolf.models.NotHostPlayerFailure
 import uk.co.suskins.pubgolf.models.Player
@@ -34,7 +39,9 @@ import uk.co.suskins.pubgolf.models.PlayerId
 import uk.co.suskins.pubgolf.models.PlayerName
 import uk.co.suskins.pubgolf.models.PlayerNotFoundFailure
 import uk.co.suskins.pubgolf.models.PubGolfFailure
+import uk.co.suskins.pubgolf.models.Routes
 import uk.co.suskins.pubgolf.models.Score
+import uk.co.suskins.pubgolf.models.toGameStateResponse
 import uk.co.suskins.pubgolf.repository.GameRepository
 import uk.co.suskins.pubgolf.repository.GameRepositoryFake
 import java.time.Instant
@@ -817,6 +824,235 @@ class GameServiceTest {
         assertThat(result, isSuccess())
         assertTrue(gameRepository.findByCodeIgnoreCase(gameCode).valueOrNull()!!.hasPlayer("Megan"))
     }
+
+    @Test
+    fun `host can set drinks and pars`() {
+        val hostPlayer = hostGame()
+
+        val result = service.setCourse(gameCode, hostPlayer.id, course())
+
+        assertThat(result, isSuccess())
+        val updatedGame = gameRepository.findByCodeIgnoreCase(gameCode).valueOrNull()!!
+        assertThat(updatedGame.holes.size, equalTo(GameConstants.MAX_HOLES))
+        assertThat(updatedGame.par(Hole(1)), equalTo(2))
+        assertThat(updatedGame.holes.first().drinks, equalTo(mapOf("Ale Trail" to "Drink 1")))
+        assertThat(eventCaptor.getEventsOfType<CourseUpdatedEvent>().single().routeNames, equalTo(listOf("Ale Trail")))
+        assertTrue(eventCaptor.getEventsOfType<GameStateChangedEvent>().isNotEmpty())
+    }
+
+    @Test
+    fun `setting the course trims names and orders holes and routes consistently`() {
+        val hostPlayer = hostGame()
+        val jumbled =
+            course(routes = listOf(" Ale Trail ", "Spirit Run"))
+                .reversed()
+                .map { hole ->
+                    // Route order differs per hole on the wire; the saved course must not.
+                    if (hole.hole.value % 2 ==
+                        0
+                    ) {
+                        hole.copy(
+                            drinks =
+                                hole.drinks.entries
+                                    .reversed()
+                                    .associate { it.key to it.value },
+                        )
+                    } else {
+                        hole
+                    }
+                }
+
+        val result = service.setCourse(gameCode, hostPlayer.id, jumbled)
+
+        assertThat(result, isSuccess())
+        val saved = gameRepository.findByCodeIgnoreCase(gameCode).valueOrNull()!!.holes
+        assertThat(saved.map { it.hole.value }, equalTo((1..GameConstants.MAX_HOLES).toList()))
+        saved.forEach { hole ->
+            assertThat(hole.drinks.keys.toList(), equalTo(listOf("Ale Trail", "Spirit Run")))
+        }
+    }
+
+    @Test
+    fun `par relative uses the game's own pars`() {
+        val hostPlayer = hostGame()
+        service.setCourse(gameCode, hostPlayer.id, course())
+        service.submitScore(gameCode, hostPlayer.id, Hole(1), Score(3))
+
+        val response = gameRepository.findByCodeIgnoreCase(gameCode).valueOrNull()!!.toGameStateResponse()
+
+        // Par 2 on the custom course where the default course has par 1.
+        assertThat(response.players.first().parRelative, equalTo(1))
+        assertThat(response.holes.first().par, equalTo(2))
+    }
+
+    @Test
+    fun `game state falls back to the default course until the host edits it`() {
+        hostGame()
+
+        val response = gameRepository.findByCodeIgnoreCase(gameCode).valueOrNull()!!.toGameStateResponse()
+
+        assertThat(response.holes.size, equalTo(GameConstants.MAX_HOLES))
+        assertThat(response.holes.first().par, equalTo(Routes.holes.first().par))
+        assertThat(response.holes.first().drinks, equalTo(Routes.holes.first().drinks))
+    }
+
+    @Test
+    fun `only the host can set drinks and pars`() {
+        hostGame()
+        val otherPlayer = Player(PlayerId.random(), PlayerName("Megan"))
+        val game = gameRepository.findByCodeIgnoreCase(gameCode).valueOrNull()!!
+        gameRepository.save(game.copy(players = game.players + otherPlayer))
+
+        val result = service.setCourse(gameCode, otherPlayer.id, course())
+
+        assertThat(result, isFailure(NotHostPlayerFailure("Only the host can change drinks and pars")))
+    }
+
+    @Test
+    fun `cannot set drinks and pars on a completed game`() {
+        val hostPlayer = hostGame(status = GameStatus.COMPLETED)
+
+        val result = service.setCourse(gameCode, hostPlayer.id, course())
+
+        assertThat(result, isFailure(GameAlreadyCompletedFailure("Cannot change the course of a completed game")))
+    }
+
+    @Test
+    fun `cannot set a course with a missing hole`() {
+        val hostPlayer = hostGame()
+
+        val result = service.setCourse(gameCode, hostPlayer.id, course().drop(1))
+
+        assertThat(result, isFailure(InvalidCourseFailure("Each hole from 1 to 9 must be set exactly once")))
+    }
+
+    @Test
+    fun `cannot set a course with a duplicated hole`() {
+        val hostPlayer = hostGame()
+        val holes = course()
+
+        val result = service.setCourse(gameCode, hostPlayer.id, holes.dropLast(1) + holes.first())
+
+        assertThat(result, isFailure(InvalidCourseFailure("Each hole from 1 to 9 must be set exactly once")))
+    }
+
+    @Test
+    fun `cannot set a par outside the allowed range`() {
+        val hostPlayer = hostGame()
+        val holes = course().map { if (it.hole == Hole(4)) it.copy(par = 11) else it }
+
+        val result = service.setCourse(gameCode, hostPlayer.id, holes)
+
+        assertThat(result, isFailure(InvalidCourseFailure("Par for hole 4 must be between 1 and 10")))
+    }
+
+    @Test
+    fun `cannot set a course with no routes`() {
+        val hostPlayer = hostGame()
+
+        val result = service.setCourse(gameCode, hostPlayer.id, course(routes = emptyList()))
+
+        assertThat(result, isFailure(InvalidCourseFailure("A course needs between 1 and 4 routes")))
+    }
+
+    @Test
+    fun `cannot set a course with too many routes`() {
+        val hostPlayer = hostGame()
+
+        val result = service.setCourse(gameCode, hostPlayer.id, course(routes = listOf("A", "B", "C", "D", "E")))
+
+        assertThat(result, isFailure(InvalidCourseFailure("A course needs between 1 and 4 routes")))
+    }
+
+    @Test
+    fun `cannot set a blank route name`() {
+        val hostPlayer = hostGame()
+
+        val result = service.setCourse(gameCode, hostPlayer.id, course(routes = listOf("  ")))
+
+        assertThat(result, isFailure(InvalidCourseFailure("Route names must not be blank")))
+    }
+
+    @Test
+    fun `cannot set duplicate route names`() {
+        val hostPlayer = hostGame()
+        val holes =
+            (1..GameConstants.MAX_HOLES).map { hole ->
+                // Same name in different cases still collides once trimmed and lowercased.
+                CourseHole(Hole(hole), 2, mapOf("Ale Trail" to "Drink $hole", "ale trail " to "Drink $hole"))
+            }
+
+        val result = service.setCourse(gameCode, hostPlayer.id, holes)
+
+        assertThat(result, isFailure(InvalidCourseFailure("Route names must be unique")))
+    }
+
+    @Test
+    fun `cannot set a route name that is too long`() {
+        val hostPlayer = hostGame()
+
+        val result = service.setCourse(gameCode, hostPlayer.id, course(routes = listOf("R".repeat(41))))
+
+        assertThat(result.failureOrNull() is InvalidCourseFailure, equalTo(true))
+    }
+
+    @Test
+    fun `cannot set a hole that is missing a route`() {
+        val hostPlayer = hostGame()
+        val holes =
+            course(routes = listOf("Ale Trail", "Spirit Run"))
+                .map { if (it.hole == Hole(7)) it.copy(drinks = mapOf("Ale Trail" to "Guinness")) else it }
+
+        val result = service.setCourse(gameCode, hostPlayer.id, holes)
+
+        assertThat(result, isFailure(InvalidCourseFailure("Hole 7 must have a drink for every route")))
+    }
+
+    @Test
+    fun `cannot set a blank drink`() {
+        val hostPlayer = hostGame()
+        val holes = course().map { if (it.hole == Hole(3)) it.copy(drinks = mapOf("Ale Trail" to " ")) else it }
+
+        val result = service.setCourse(gameCode, hostPlayer.id, holes)
+
+        assertThat(result, isFailure(InvalidCourseFailure("Drink for hole 3 on `Ale Trail` must not be blank")))
+    }
+
+    @Test
+    fun `cannot set a drink that is too long`() {
+        val hostPlayer = hostGame()
+        val holes = course().map { if (it.hole == Hole(3)) it.copy(drinks = mapOf("Ale Trail" to "D".repeat(101))) else it }
+
+        val result = service.setCourse(gameCode, hostPlayer.id, holes)
+
+        assertThat(result.failureOrNull() is InvalidCourseFailure, equalTo(true))
+    }
+
+    @Test
+    fun `cannot set drinks and pars for a game that doesn't exist`() {
+        val result = service.setCourse(gameCode, PlayerId.random(), course())
+
+        assertThat(result, isFailure(GameNotFoundFailure("Game `ACE007` not found.")))
+    }
+
+    private fun hostGame(status: GameStatus = GameStatus.ACTIVE): Player {
+        val hostPlayer = Player(PlayerId.random(), host)
+        gameRepository.save(
+            Game(
+                id = GameId.random(),
+                code = gameCode,
+                players = listOf(hostPlayer),
+                status = status,
+                hostPlayerId = hostPlayer.id,
+            ),
+        )
+        return hostPlayer
+    }
+
+    private fun course(routes: List<String> = listOf("Ale Trail")): List<CourseHole> =
+        (1..GameConstants.MAX_HOLES).map { hole ->
+            CourseHole(Hole(hole), 2, routes.associateWith { "Drink $hole" })
+        }
 
     @Test
     fun `gives up after repeated concurrent modification failures`() {

--- a/apps/backend/src/test/resources/uk/co/suskins/pubgolf/approvals/OpenApiTest.Can generate an open api spec.approved
+++ b/apps/backend/src/test/resources/uk/co/suskins/pubgolf/approvals/OpenApiTest.Can generate an open api spec.approved
@@ -120,6 +120,112 @@
         } ]
       }
     },
+    "/api/v1/games/{gameCode}/holes" : {
+      "put" : {
+        "tags" : [ "game-controller" ],
+        "operationId" : "setHoles-oU5FXdQ",
+        "parameters" : [ {
+          "name" : "gameCode",
+          "in" : "path",
+          "required" : true,
+          "schema" : {
+            "type" : "string"
+          }
+        }, {
+          "name" : "PubGolf-Player-Id",
+          "in" : "header",
+          "required" : false,
+          "schema" : {
+            "type" : "string"
+          }
+        } ],
+        "requestBody" : {
+          "content" : {
+            "application/json" : {
+              "schema" : {
+                "$ref" : "#/components/schemas/SetHolesRequest"
+              }
+            }
+          },
+          "required" : true
+        },
+        "responses" : {
+          "200" : {
+            "description" : "Course set for the game (replaces any existing drinks and pars)",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/GameStateResponse"
+                }
+              }
+            }
+          },
+          "400" : {
+            "description" : "Invalid argument",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "401" : {
+            "description" : "Unauthorized - Missing or invalid player ID header",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "403" : {
+            "description" : "Forbidden - Not the host or not in this game",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "404" : {
+            "description" : "Game, player or event not found",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "409" : {
+            "description" : "Conflict with the game's current state",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          },
+          "500" : {
+            "description" : "Unexpected error",
+            "content" : {
+              "application/json" : {
+                "schema" : {
+                  "$ref" : "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "security" : [ {
+          "PlayerIdHeader" : [ ]
+        } ]
+      }
+    },
     "/api/v1/games/{gameCode}/active-event" : {
       "put" : {
         "tags" : [ "game-controller" ],
@@ -1346,15 +1452,43 @@
         },
         "required" : [ "message" ]
       },
-      "SetActiveEventRequest" : {
+      "CourseHoleDto" : {
         "type" : "object",
         "properties" : {
-          "eventId" : {
-            "type" : "string",
-            "minLength" : 1
+          "hole" : {
+            "type" : "integer",
+            "format" : "int32",
+            "maximum" : 9,
+            "minimum" : 1
+          },
+          "par" : {
+            "type" : "integer",
+            "format" : "int32",
+            "maximum" : 10,
+            "minimum" : 1
+          },
+          "drinks" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            }
           }
         },
-        "required" : [ "eventId" ]
+        "required" : [ "drinks", "hole", "par" ]
+      },
+      "SetHolesRequest" : {
+        "type" : "object",
+        "properties" : {
+          "holes" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/CourseHoleDto"
+            },
+            "maxItems" : 9,
+            "minItems" : 9
+          }
+        },
+        "required" : [ "holes" ]
       },
       "ActiveEventResponse" : {
         "type" : "object",
@@ -1401,9 +1535,35 @@
           },
           "activeEvent" : {
             "$ref" : "#/components/schemas/ActiveEventResponse"
+          },
+          "holes" : {
+            "type" : "array",
+            "items" : {
+              "$ref" : "#/components/schemas/HoleResponse"
+            }
           }
         },
-        "required" : [ "gameCode", "gameId", "players", "status" ]
+        "required" : [ "gameCode", "gameId", "holes", "players", "status" ]
+      },
+      "HoleResponse" : {
+        "type" : "object",
+        "properties" : {
+          "hole" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "par" : {
+            "type" : "integer",
+            "format" : "int32"
+          },
+          "drinks" : {
+            "type" : "object",
+            "additionalProperties" : {
+              "type" : "string"
+            }
+          }
+        },
+        "required" : [ "drinks", "hole", "par" ]
       },
       "PenaltyResponse" : {
         "type" : "object",
@@ -1480,6 +1640,16 @@
           }
         },
         "required" : [ "value" ]
+      },
+      "SetActiveEventRequest" : {
+        "type" : "object",
+        "properties" : {
+          "eventId" : {
+            "type" : "string",
+            "minLength" : 1
+          }
+        },
+        "required" : [ "eventId" ]
       },
       "SetCustomActiveEventRequest" : {
         "type" : "object",
@@ -1694,26 +1864,6 @@
             "$ref" : "#/components/schemas/ActiveEventResponse"
           }
         }
-      },
-      "HoleResponse" : {
-        "type" : "object",
-        "properties" : {
-          "hole" : {
-            "type" : "integer",
-            "format" : "int32"
-          },
-          "par" : {
-            "type" : "integer",
-            "format" : "int32"
-          },
-          "drinks" : {
-            "type" : "object",
-            "additionalProperties" : {
-              "type" : "string"
-            }
-          }
-        },
-        "required" : [ "drinks", "hole", "par" ]
       },
       "RoutesResponse" : {
         "type" : "object",

--- a/apps/frontend/app/game/[code]/host/page.tsx
+++ b/apps/frontend/app/game/[code]/host/page.tsx
@@ -3,15 +3,16 @@
 import { useEffect, useState, useCallback } from 'react';
 import { useRouter, useParams } from 'next/navigation';
 import Link from 'next/link';
-import { getGameState, getAvailableEvents, activateEvent, activateCustomEvent, endEvent, completeGame, getRoute } from '@/lib/api';
+import { getGameState, getAvailableEvents, activateEvent, activateCustomEvent, endEvent, completeGame, getRoute, setHoles } from '@/lib/api';
 import { useLocalStorage } from '@/hooks/useLocalStorage';
 import { useGameWebSocket } from '@/hooks/useGameWebSocket';
 import { EventCard } from '@/components/EventCard';
+import { CourseEditor } from '@/components/CourseEditor';
 import { ConfirmModal } from '@/components/ConfirmModal';
 import { EmptyState } from '@/components/ui/EmptyState';
 import { ErrorMessage } from '@/components/ui/ErrorMessage';
 import { Input } from '@/components/ui/Input';
-import { GameEvent, GameState, ActiveEvent } from '@/lib/types';
+import { GameEvent, GameState, ActiveEvent, RouteHole } from '@/lib/types';
 
 export default function HostPanelPage() {
   const [events, setEvents] = useState<GameEvent[]>([]);
@@ -26,6 +27,7 @@ export default function HostPanelPage() {
   const [customDescription, setCustomDescription] = useState('');
   const [activatingCustom, setActivatingCustom] = useState(false);
   const [hasRoute, setHasRoute] = useState(false);
+  const [course, setCourse] = useState<RouteHole[]>([]);
   const [showEndGameModal, setShowEndGameModal] = useState(false);
   const [completing, setCompleting] = useState(false);
   const router = useRouter();
@@ -36,6 +38,7 @@ export default function HostPanelPage() {
   const handleGameStateUpdate = useCallback((state: GameState) => {
     setActiveEvent(state.activeEvent);
     setGameStatus(state.status);
+    setCourse(state.holes);
   }, []);
 
   useGameWebSocket({
@@ -60,6 +63,7 @@ export default function HostPanelPage() {
 
         setActiveEvent(state.activeEvent);
         setGameStatus(state.status);
+        setCourse(state.holes);
         setEvents(eventsResponse.events);
 
         const playerId = getPlayerId();
@@ -146,6 +150,14 @@ export default function HostPanelPage() {
     } finally {
       setEndingEvent(false);
     }
+  };
+
+  const handleSaveCourse = async (updated: RouteHole[]) => {
+    const playerId = getPlayerId();
+    if (!playerId || !gameCode) return;
+
+    const state = await setHoles(gameCode, playerId, updated);
+    setCourse(state.holes);
   };
 
   const handleCompleteGame = async () => {
@@ -255,6 +267,17 @@ export default function HostPanelPage() {
           >
             {hasRoute ? 'Edit route map' : 'Set up route map'}
           </Link>
+        </section>
+
+        <section>
+          <h2 className="eyebrow text-[12.5px] text-[var(--color-text-muted)] mb-2.5">
+            Drinks &amp; Pars
+          </h2>
+          {course.length === 0 ? (
+            <EmptyState icon="🍺" description="Course unavailable — reload to try again" />
+          ) : (
+            <CourseEditor holes={course} onSave={handleSaveCourse} />
+          )}
         </section>
 
         <section>

--- a/apps/frontend/app/game/page.tsx
+++ b/apps/frontend/app/game/page.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { toast } from 'sonner';
 import { AnimatePresence } from 'framer-motion';
-import { getGameState, getRoutes, getRoute } from '@/lib/api';
+import { getGameState, getRoute } from '@/lib/api';
 import { useLocalStorage } from '@/hooks/useLocalStorage';
 import { useSessionStorage } from '@/hooks/useSessionStorage';
 import { useGameWebSocket } from '@/hooks/useGameWebSocket';
@@ -19,12 +19,8 @@ import { Player, GameState } from '@/lib/types';
 import { firstUnplayedHole, playerParRelative } from '@/lib/scoring';
 import { ErrorMessage } from '@/components/ui/ErrorMessage';
 
-// Fallback while /api/v1/config/routes loads; keep in sync with the backend Routes config.
-const DEFAULT_PARS = [1, 3, 2, 2, 2, 2, 4, 1, 1];
-
 export default function GamePage() {
   const [committedGameState, setCommittedGameState] = useState<GameState | null>(null);
-  const [pars, setPars] = useState<number[]>(DEFAULT_PARS);
   const [gameCode, setGameCode] = useState<string>('');
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
@@ -43,6 +39,8 @@ export default function GamePage() {
   const status = committedGameState?.status || 'ACTIVE';
   const hostPlayerId = committedGameState?.hostPlayerId || null;
   const activeEvent = committedGameState?.activeEvent || null;
+  // The course comes with game state, so a host's par edit re-ranks the board live.
+  const pars = (committedGameState?.holes ?? []).map((hole) => hole.par);
 
   const handleGameStateUpdate = useCallback((state: GameState) => {
     setCommittedGameState(state);
@@ -119,12 +117,6 @@ export default function GamePage() {
       window.removeEventListener('focus', refreshIfVisible);
     };
   }, [fetchGame]);
-
-  useEffect(() => {
-    getRoutes()
-      .then((response) => setPars(response.holes.map((hole) => hole.par)))
-      .catch((err) => console.warn('Could not load par data, using defaults:', err));
-  }, []);
 
   useEffect(() => {
     const queuedEventId = getQueuedEventId();

--- a/apps/frontend/app/how-to-play/page.test.tsx
+++ b/apps/frontend/app/how-to-play/page.test.tsx
@@ -16,9 +16,27 @@ const mockGetRoutes = mock(() => Promise.resolve({
   ]
 }));
 
+const mockGetGameState = mock(() => Promise.resolve({
+  holes: [
+    { hole: 1, par: 4, drinks: { 'Ale Trail': 'Guinness' } }
+  ]
+}));
+
 mock.module('@/lib/api', () => ({
   getPenaltyOptions: mockGetPenaltyOptions,
   getRoutes: mockGetRoutes,
+  getGameState: mockGetGameState,
+}));
+
+// No stored game by default, so the page falls back to the default course.
+const mockGetGameCode = mock<() => string | null>(() => null);
+mock.module('@/hooks/useLocalStorage', () => ({
+  useLocalStorage: () => ({
+    getGameCode: mockGetGameCode,
+    getPlayerId: () => null,
+    setGameSession: () => {},
+    clearSession: () => {},
+  }),
 }));
 
 mock.module('next/navigation', () => ({
@@ -40,6 +58,10 @@ describe('HowToPlayPage', () => {
         { hole: 1, par: 1, drinks: { 'Route A': 'Beer', 'Route B': 'Wine' } }
       ]
     }));
+    mockGetPenaltyOptions.mockClear();
+    mockGetRoutes.mockClear();
+    mockGetGameState.mockClear();
+    mockGetGameCode.mockImplementation(() => null);
   });
 
   describe('loading states', () => {
@@ -108,6 +130,28 @@ describe('HowToPlayPage', () => {
       render(<HowToPlayPage />);
 
       expect(screen.getByText(/finish your drink in as few sips/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('game course', () => {
+    test("should render the game's own course when in a game", async () => {
+      mockGetGameCode.mockImplementation(() => 'ACE007');
+      render(<HowToPlayPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Guinness')).toBeInTheDocument();
+      });
+      expect(mockGetGameState).toHaveBeenCalledWith('ACE007');
+      expect(mockGetRoutes).not.toHaveBeenCalled();
+    });
+
+    test('should fall back to the default course when not in a game', async () => {
+      render(<HowToPlayPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Route A')).toBeInTheDocument();
+      });
+      expect(mockGetGameState).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/frontend/app/how-to-play/page.tsx
+++ b/apps/frontend/app/how-to-play/page.tsx
@@ -2,8 +2,9 @@
 
 import { useEffect, useState } from 'react';
 import { RULES } from '@/lib/constants';
-import { getPenaltyOptions, getRoutes, PenaltyOption } from '@/lib/api';
+import { getPenaltyOptions, getRoutes, getGameState, PenaltyOption } from '@/lib/api';
 import { PENALTY_EMOJI_MAP, PenaltyType, RouteHole } from '@/lib/types';
+import { useLocalStorage } from '@/hooks/useLocalStorage';
 import { BackButton } from './BackButton';
 import { RoutesTable } from '@/components/RoutesTable';
 import { Card } from '@/components/ui/Card';
@@ -72,6 +73,7 @@ export default function HowToPlayPage() {
   const [isRoutesLoading, setIsRoutesLoading] = useState(true);
   const [penaltiesError, setPenaltiesError] = useState(false);
   const [routesError, setRoutesError] = useState(false);
+  const { getGameCode } = useLocalStorage();
 
   useEffect(() => {
     getPenaltyOptions()
@@ -79,11 +81,18 @@ export default function HowToPlayPage() {
       .catch(() => setPenaltiesError(true))
       .finally(() => setIsPenaltiesLoading(false));
 
-    getRoutes()
-      .then((response) => setHoles(response.holes))
+    // In a game, show that game's course (the host can have customised it);
+    // otherwise fall back to the default course.
+    const gameCode = getGameCode();
+    const course = gameCode
+      ? getGameState(gameCode).then((state) => state.holes)
+      : getRoutes().then((response) => response.holes);
+
+    course
+      .then(setHoles)
       .catch(() => setRoutesError(true))
       .finally(() => setIsRoutesLoading(false));
-  }, []);
+  }, [getGameCode]);
 
   return (
     <main className="p-5 py-6">

--- a/apps/frontend/app/submit-score/page.tsx
+++ b/apps/frontend/app/submit-score/page.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
-import { submitScore, getPenaltyOptions, PenaltyOption, getRoutes, getGameState, getRoute } from '@/lib/api';
+import { submitScore, getPenaltyOptions, PenaltyOption, getGameState, getRoute } from '@/lib/api';
 import { useLocalStorage } from '@/hooks/useLocalStorage';
 import { PenaltyType, PubLocation } from '@/lib/types';
 import { firstUnplayedHole } from '@/lib/scoring';
@@ -41,9 +41,8 @@ export default function SubmitScorePage() {
 
       if (!gameCode || !playerId) return;
 
-      const [penaltiesResult, routesResult, gameStateResult, routeResult] = await Promise.allSettled([
+      const [penaltiesResult, gameStateResult, routeResult] = await Promise.allSettled([
         getPenaltyOptions(),
-        getRoutes(),
         getGameState(gameCode),
         getRoute(gameCode),
       ]);
@@ -51,13 +50,12 @@ export default function SubmitScorePage() {
       if (penaltiesResult.status === 'fulfilled') {
         setPenaltyOptions(penaltiesResult.value.penalties);
       }
-      if (routesResult.status === 'fulfilled') {
-        setPars(routesResult.value.holes.map((h) => h.par));
-      }
       if (routeResult.status === 'fulfilled') {
         setPubs(routeResult.value.pubs);
       }
       if (gameStateResult.status === 'fulfilled') {
+        // Pars are the host's, not global config, so they ride along with game state.
+        setPars(gameStateResult.value.holes.map((h) => h.par));
         const currentPlayer = gameStateResult.value.players.find((p) => p.id === playerId);
         if (currentPlayer) {
           setPlayerScores(currentPlayer.scores);

--- a/apps/frontend/components/CourseEditor.test.tsx
+++ b/apps/frontend/components/CourseEditor.test.tsx
@@ -1,0 +1,188 @@
+import { describe, test, expect, mock } from 'bun:test';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { CourseEditor } from './CourseEditor';
+import type { RouteHole } from '@/lib/types';
+
+const holes: RouteHole[] = [
+  { hole: 1, par: 1, drinks: { 'Route A': 'Tequila', 'Route B': 'Sambuca' } },
+  { hole: 2, par: 3, drinks: { 'Route A': 'Beer', 'Route B': 'Vodka' } },
+];
+
+describe('CourseEditor', () => {
+  describe('rendering', () => {
+    test('should render a drink field per route for every hole', () => {
+      render(<CourseEditor holes={holes} onSave={mock(async () => {})} />);
+
+      expect(screen.getByLabelText('Hole 1 drink on Route A')).toHaveValue('Tequila');
+      expect(screen.getByLabelText('Hole 1 drink on Route B')).toHaveValue('Sambuca');
+      expect(screen.getByLabelText('Hole 2 drink on Route A')).toHaveValue('Beer');
+      expect(screen.getByLabelText('Hole 2 par')).toHaveValue(3);
+    });
+
+    test('should render an editable name per route', () => {
+      render(<CourseEditor holes={holes} onSave={mock(async () => {})} />);
+
+      expect(screen.getByLabelText('Route 1 name')).toHaveValue('Route A');
+      expect(screen.getByLabelText('Route 2 name')).toHaveValue('Route B');
+    });
+
+    test('should disable save until something changes', () => {
+      render(<CourseEditor holes={holes} onSave={mock(async () => {})} />);
+
+      expect(screen.getByRole('button', { name: /save drinks & pars/i })).toBeDisabled();
+    });
+  });
+
+  describe('editing', () => {
+    test('should save edited drinks and pars', async () => {
+      const user = userEvent.setup();
+      const onSave = mock(async () => {});
+      render(<CourseEditor holes={holes} onSave={onSave} />);
+
+      await user.clear(screen.getByLabelText('Hole 1 drink on Route A'));
+      await user.type(screen.getByLabelText('Hole 1 drink on Route A'), 'Cider');
+      await user.click(screen.getByRole('button', { name: /save drinks & pars/i }));
+
+      await waitFor(() => {
+        expect(onSave).toHaveBeenCalledWith([
+          { hole: 1, par: 1, drinks: { 'Route A': 'Cider', 'Route B': 'Sambuca' } },
+          { hole: 2, par: 3, drinks: { 'Route A': 'Beer', 'Route B': 'Vodka' } },
+        ]);
+      });
+    });
+
+    test('should keep a route column when it is renamed', async () => {
+      const user = userEvent.setup();
+      const onSave = mock(async () => {});
+      render(<CourseEditor holes={holes} onSave={onSave} />);
+
+      await user.clear(screen.getByLabelText('Route 1 name'));
+      await user.type(screen.getByLabelText('Route 1 name'), 'Ale Trail');
+      await user.click(screen.getByRole('button', { name: /save drinks & pars/i }));
+
+      await waitFor(() => {
+        expect(onSave).toHaveBeenCalledWith([
+          { hole: 1, par: 1, drinks: { 'Ale Trail': 'Tequila', 'Route B': 'Sambuca' } },
+          { hole: 2, par: 3, drinks: { 'Ale Trail': 'Beer', 'Route B': 'Vodka' } },
+        ]);
+      });
+    });
+
+    test('should add a route with an empty drink for every hole', async () => {
+      const user = userEvent.setup();
+      render(<CourseEditor holes={holes} onSave={mock(async () => {})} />);
+
+      await user.click(screen.getByRole('button', { name: /\+ route/i }));
+
+      expect(screen.getByLabelText('Route 3 name')).toHaveValue('Route C');
+      expect(screen.getByLabelText('Hole 1 drink on Route C')).toHaveValue('');
+    });
+
+    test('should remove a route and its drinks', async () => {
+      const user = userEvent.setup();
+      const onSave = mock(async () => {});
+      render(<CourseEditor holes={holes} onSave={onSave} />);
+
+      await user.click(screen.getByRole('button', { name: /remove route b/i }));
+      await user.click(screen.getByRole('button', { name: /save drinks & pars/i }));
+
+      await waitFor(() => {
+        expect(onSave).toHaveBeenCalledWith([
+          { hole: 1, par: 1, drinks: { 'Route A': 'Tequila' } },
+          { hole: 2, par: 3, drinks: { 'Route A': 'Beer' } },
+        ]);
+      });
+    });
+
+    test('should not offer to remove the only route', () => {
+      render(
+        <CourseEditor
+          holes={[{ hole: 1, par: 1, drinks: { Classic: 'Tequila' } }]}
+          onSave={mock(async () => {})}
+        />
+      );
+
+      expect(screen.queryByRole('button', { name: /remove/i })).not.toBeInTheDocument();
+    });
+
+    test('should discard changes on reset', async () => {
+      const user = userEvent.setup();
+      render(<CourseEditor holes={holes} onSave={mock(async () => {})} />);
+
+      await user.clear(screen.getByLabelText('Hole 1 drink on Route A'));
+      await user.type(screen.getByLabelText('Hole 1 drink on Route A'), 'Cider');
+      await user.click(screen.getByRole('button', { name: /reset/i }));
+
+      expect(screen.getByLabelText('Hole 1 drink on Route A')).toHaveValue('Tequila');
+    });
+  });
+
+  describe('validation', () => {
+    test('should reject a blank drink without calling the API', async () => {
+      const user = userEvent.setup();
+      const onSave = mock(async () => {});
+      render(<CourseEditor holes={holes} onSave={onSave} />);
+
+      await user.clear(screen.getByLabelText('Hole 2 drink on Route B'));
+      await user.click(screen.getByRole('button', { name: /save drinks & pars/i }));
+
+      expect(screen.getByText(/every route needs a drink for hole 2/i)).toBeInTheDocument();
+      expect(onSave).not.toHaveBeenCalled();
+    });
+
+    test('should reject a blank route name', async () => {
+      const user = userEvent.setup();
+      const onSave = mock(async () => {});
+      render(<CourseEditor holes={holes} onSave={onSave} />);
+
+      await user.clear(screen.getByLabelText('Route 2 name'));
+      await user.click(screen.getByRole('button', { name: /save drinks & pars/i }));
+
+      expect(screen.getByText(/every route needs a name/i)).toBeInTheDocument();
+      expect(onSave).not.toHaveBeenCalled();
+    });
+
+    test('should reject duplicate route names', async () => {
+      const user = userEvent.setup();
+      const onSave = mock(async () => {});
+      render(<CourseEditor holes={holes} onSave={onSave} />);
+
+      await user.clear(screen.getByLabelText('Route 2 name'));
+      await user.type(screen.getByLabelText('Route 2 name'), 'route a');
+      await user.click(screen.getByRole('button', { name: /save drinks & pars/i }));
+
+      expect(screen.getByText(/route names must be unique/i)).toBeInTheDocument();
+      expect(onSave).not.toHaveBeenCalled();
+    });
+
+    test('should reject a par outside the allowed range', async () => {
+      const user = userEvent.setup();
+      const onSave = mock(async () => {});
+      render(<CourseEditor holes={holes} onSave={onSave} />);
+
+      await user.clear(screen.getByLabelText('Hole 1 par'));
+      await user.type(screen.getByLabelText('Hole 1 par'), '11');
+      await user.click(screen.getByRole('button', { name: /save drinks & pars/i }));
+
+      expect(screen.getByText(/par for hole 1 must be between 1 and 10/i)).toBeInTheDocument();
+      expect(onSave).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('error handling', () => {
+    test('should show the failure from the API', async () => {
+      const user = userEvent.setup();
+      const onSave = mock(() => Promise.reject(new Error('Only the host can change drinks and pars')));
+      render(<CourseEditor holes={holes} onSave={onSave} />);
+
+      await user.clear(screen.getByLabelText('Hole 1 drink on Route A'));
+      await user.type(screen.getByLabelText('Hole 1 drink on Route A'), 'Cider');
+      await user.click(screen.getByRole('button', { name: /save drinks & pars/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/only the host can change drinks and pars/i)).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/apps/frontend/components/CourseEditor.tsx
+++ b/apps/frontend/components/CourseEditor.tsx
@@ -1,0 +1,252 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import type { RouteHole } from '@/lib/types';
+import { Input } from './ui/Input';
+import { Button } from './ui/Button';
+import { ErrorMessage } from './ui/ErrorMessage';
+
+const MIN_PAR = 1;
+const MAX_PAR = 10;
+const MAX_ROUTES = 4;
+const MAX_ROUTE_NAME_LENGTH = 40;
+const MAX_DRINK_LENGTH = 100;
+
+interface CourseEditorProps {
+  /** The game's current course, as served with game state. */
+  holes: RouteHole[];
+  /** Resolves once the course is saved; rejects with a message to display. */
+  onSave: (holes: RouteHole[]) => Promise<void>;
+  disabled?: boolean;
+}
+
+// Editing keeps route names in a list and drinks in a parallel matrix so a route
+// can be renamed without losing its column, which a Record<name, drink> would.
+interface DraftHole {
+  hole: number;
+  par: number;
+  drinks: string[];
+}
+
+interface Draft {
+  routeNames: string[];
+  holes: DraftHole[];
+}
+
+function toDraft(holes: RouteHole[]): Draft {
+  const routeNames = Object.keys(holes[0]?.drinks ?? {});
+  return {
+    routeNames,
+    holes: holes.map((hole) => ({
+      hole: hole.hole,
+      par: hole.par,
+      drinks: routeNames.map((name) => hole.drinks[name] ?? ''),
+    })),
+  };
+}
+
+function toRouteHoles(draft: Draft): RouteHole[] {
+  return draft.holes.map((hole) => ({
+    hole: hole.hole,
+    par: hole.par,
+    drinks: Object.fromEntries(
+      draft.routeNames.map((name, index) => [name.trim(), hole.drinks[index].trim()])
+    ),
+  }));
+}
+
+// Mirrors the backend's InvalidCourseFailure rules so the host sees the problem
+// before a round trip.
+function validate(draft: Draft): string | null {
+  const names = draft.routeNames.map((name) => name.trim());
+  if (names.length === 0) {
+    return 'Add at least one route';
+  }
+  if (names.some((name) => name.length === 0)) {
+    return 'Every route needs a name';
+  }
+  if (new Set(names.map((name) => name.toLowerCase())).size !== names.length) {
+    return 'Route names must be unique';
+  }
+  for (const hole of draft.holes) {
+    if (hole.par < MIN_PAR || hole.par > MAX_PAR) {
+      return `Par for hole ${hole.hole} must be between ${MIN_PAR} and ${MAX_PAR}`;
+    }
+    if (hole.drinks.some((drink) => drink.trim().length === 0)) {
+      return `Every route needs a drink for hole ${hole.hole}`;
+    }
+  }
+  return null;
+}
+
+export function CourseEditor({ holes, onSave, disabled = false }: CourseEditorProps) {
+  const initial = useMemo(() => toDraft(holes), [holes]);
+  // The draft deliberately survives incoming game-state updates so an edit in
+  // progress is never wiped; Reset pulls the latest saved course back in.
+  const [draft, setDraft] = useState<Draft>(initial);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+  const [saved, setSaved] = useState(false);
+
+  const dirty = JSON.stringify(draft) !== JSON.stringify(initial);
+
+  const update = (next: Draft) => {
+    setDraft(next);
+    setSaved(false);
+    setError('');
+  };
+
+  const renameRoute = (index: number, name: string) => {
+    update({
+      ...draft,
+      routeNames: draft.routeNames.map((existing, i) => (i === index ? name : existing)),
+    });
+  };
+
+  const addRoute = () => {
+    update({
+      routeNames: [...draft.routeNames, `Route ${String.fromCharCode(65 + draft.routeNames.length)}`],
+      holes: draft.holes.map((hole) => ({ ...hole, drinks: [...hole.drinks, ''] })),
+    });
+  };
+
+  const removeRoute = (index: number) => {
+    update({
+      routeNames: draft.routeNames.filter((_, i) => i !== index),
+      holes: draft.holes.map((hole) => ({
+        ...hole,
+        drinks: hole.drinks.filter((_, i) => i !== index),
+      })),
+    });
+  };
+
+  const setPar = (holeIndex: number, par: number) => {
+    update({
+      ...draft,
+      holes: draft.holes.map((hole, i) => (i === holeIndex ? { ...hole, par } : hole)),
+    });
+  };
+
+  const setDrink = (holeIndex: number, routeIndex: number, drink: string) => {
+    update({
+      ...draft,
+      holes: draft.holes.map((hole, i) =>
+        i === holeIndex
+          ? { ...hole, drinks: hole.drinks.map((existing, j) => (j === routeIndex ? drink : existing)) }
+          : hole
+      ),
+    });
+  };
+
+  const handleSave = async () => {
+    const validationError = validate(draft);
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+
+    setError('');
+    setSaving(true);
+    try {
+      await onSave(toRouteHoles(draft));
+      setSaved(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save drinks and pars');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const busy = saving || disabled;
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-end gap-2">
+        {draft.routeNames.map((name, index) => (
+          <div key={index} className="flex items-end gap-1">
+            <Input
+              size="sm"
+              value={name}
+              onChange={(e) => renameRoute(index, e.target.value)}
+              maxLength={MAX_ROUTE_NAME_LENGTH}
+              disabled={busy}
+              aria-label={`Route ${index + 1} name`}
+              className="w-[9.5rem]"
+            />
+            {draft.routeNames.length > 1 && (
+              <Button
+                variant="danger"
+                size="sm"
+                onClick={() => removeRoute(index)}
+                disabled={busy}
+                ariaLabel={`Remove ${name || `route ${index + 1}`}`}
+              >
+                ✕
+              </Button>
+            )}
+          </div>
+        ))}
+        {draft.routeNames.length < MAX_ROUTES && (
+          <Button variant="secondary" size="sm" onClick={addRoute} disabled={busy}>
+            + Route
+          </Button>
+        )}
+      </div>
+
+      <ul className="space-y-2">
+        {draft.holes.map((hole, holeIndex) => (
+          <li
+            key={hole.hole}
+            className="glass rounded-[14px] p-3 flex flex-wrap items-end gap-2"
+          >
+            <span className="font-display text-[var(--color-primary)] w-5 pb-3" aria-hidden="true">
+              {hole.hole}
+            </span>
+            {hole.drinks.map((drink, routeIndex) => (
+              <Input
+                key={routeIndex}
+                size="sm"
+                value={drink}
+                onChange={(e) => setDrink(holeIndex, routeIndex, e.target.value)}
+                maxLength={MAX_DRINK_LENGTH}
+                placeholder="Drink"
+                disabled={busy}
+                aria-label={`Hole ${hole.hole} drink on ${draft.routeNames[routeIndex] || `route ${routeIndex + 1}`}`}
+                className="w-[9.5rem]"
+              />
+            ))}
+            <Input
+              size="sm"
+              type="number"
+              min={MIN_PAR}
+              max={MAX_PAR}
+              value={hole.par}
+              onChange={(e) => setPar(holeIndex, Number(e.target.value))}
+              disabled={busy}
+              aria-label={`Hole ${hole.hole} par`}
+              className="w-[4.5rem]"
+            />
+          </li>
+        ))}
+      </ul>
+
+      {error && <ErrorMessage message={error} variant="inline" />}
+
+      <div className="flex items-center gap-2">
+        <Button variant="primary" size="sm" onClick={handleSave} loading={saving} disabled={disabled || !dirty}>
+          {saving ? 'Saving...' : 'Save Drinks & Pars'}
+        </Button>
+        {dirty && !saving && (
+          <Button variant="ghost" size="sm" onClick={() => update(initial)} disabled={busy}>
+            Reset
+          </Button>
+        )}
+        {saved && !dirty && (
+          <p className="text-[12.5px] text-[var(--color-accent)]" role="status">
+            Saved — all players updated
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/components/CreateGameForm.tsx
+++ b/apps/frontend/components/CreateGameForm.tsx
@@ -12,7 +12,6 @@ export function CreateGameForm() {
   const [name, setName] = useState('');
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
-  const [addPubRoute, setAddPubRoute] = useState(false);
   const router = useRouter();
   const { setGameSession } = useLocalStorage();
 
@@ -29,7 +28,7 @@ export function CreateGameForm() {
     try {
       const response = await createGame(name.trim());
       setGameSession(response.gameCode, response.playerId);
-      router.push(addPubRoute ? '/game/route' : '/game');
+      router.push('/game');
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to create game');
     } finally {
@@ -49,34 +48,6 @@ export function CreateGameForm() {
         disabled={loading}
         fullWidth
       />
-
-      <div className="flex items-center justify-between py-1">
-        <div>
-          <div className="text-sm font-semibold text-[var(--color-text)]">Add route map</div>
-          <div className="text-xs text-[var(--color-text-muted)] mt-0.5">
-            Show pub order to players
-          </div>
-        </div>
-        <button
-          type="button"
-          role="switch"
-          aria-checked={addPubRoute}
-          aria-label="Add route map"
-          disabled={loading}
-          onClick={() => setAddPubRoute(!addPubRoute)}
-          className={`w-11 h-[26px] rounded-full relative transition-colors shrink-0 ${
-            addPubRoute ? 'bg-[var(--color-primary)]' : 'bg-[var(--color-border-subtle)]'
-          }`}
-        >
-          <span
-            className={`w-5 h-5 rounded-full absolute top-[3px] transition-all ${
-              addPubRoute
-                ? 'left-[21px] bg-[var(--color-ink)]'
-                : 'left-[3px] bg-[var(--color-text-secondary)]'
-            }`}
-          />
-        </button>
-      </div>
 
       {error && <ErrorMessage message={error} variant="inline" />}
       <Button

--- a/apps/frontend/lib/api.ts
+++ b/apps/frontend/lib/api.ts
@@ -1,6 +1,6 @@
 import { toast } from 'sonner';
 import { STORAGE_KEYS } from '@/hooks/useLocalStorage';
-import { CreateGameResponse, JoinGameResponse, GameState, PenaltyType, RoutesResponse, GameEvent, ActiveEvent, PlaceSearchResult, Pub, RouteData } from './types';
+import { CreateGameResponse, JoinGameResponse, GameState, PenaltyType, RouteHole, RoutesResponse, GameEvent, ActiveEvent, PlaceSearchResult, Pub, RouteData } from './types';
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'https://api.pubgolf.me';
 const FETCH_TIMEOUT_MS = 15_000;
@@ -267,6 +267,16 @@ export async function setPubs(
 
 export async function getRoute(gameCode: string): Promise<RouteData> {
   return request(gamePath(gameCode, '/route'));
+}
+
+// Replaces the game's whole course. Returns the updated state, which is also
+// broadcast to every connected player.
+export async function setHoles(
+  gameCode: string,
+  playerId: string,
+  holes: RouteHole[]
+): Promise<GameState> {
+  return request(gamePath(gameCode, '/holes'), { method: 'PUT', body: { holes }, playerId });
 }
 
 export { ApiError };

--- a/apps/frontend/lib/types.ts
+++ b/apps/frontend/lib/types.ts
@@ -50,6 +50,8 @@ export interface GameState {
   hostPlayerId: string | null;
   players: Player[];
   activeEvent: ActiveEvent | null;
+  /** The game's own course — the host's drinks/pars, or the defaults if never edited. */
+  holes: RouteHole[];
 }
 
 export interface CreateGameResponse {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -29,7 +29,7 @@ flowchart LR
 
 | Component | Responsibility | Location |
 |-----------|----------------|----------|
-| REST controllers | HTTP endpoints for game lifecycle, scoring, randomise, pubs | `apps/backend/src/main/kotlin/uk/co/suskins/pubgolf/controller` |
+| REST controllers | HTTP endpoints for game lifecycle, scoring, randomise, pubs, course | `apps/backend/src/main/kotlin/uk/co/suskins/pubgolf/controller` |
 | Services | Business logic, returns `Result<T, PubGolfFailure>` | `apps/backend/src/main/kotlin/uk/co/suskins/pubgolf/service` |
 | Repositories | Data access interfaces + JPA adapters | `apps/backend/src/main/kotlin/uk/co/suskins/pubgolf/repository` |
 | Domain models | `Game`, `Player`, `Score`, `Pub`, etc. | `apps/backend/src/main/kotlin/uk/co/suskins/pubgolf/models/Domain.kt` |
@@ -97,6 +97,7 @@ sequenceDiagram
 erDiagram
     GAME ||--o{ PLAYER : has
     GAME ||--o{ PUB : visits
+    GAME ||--o{ COURSE_HOLE : "drinks & pars"
     PLAYER ||--o{ SCORE : records
     PLAYER ||--o{ PENALTY : incurs
     PLAYER ||--o| RANDOMISE : "current twist"
@@ -124,13 +125,20 @@ erDiagram
         int order
         string name
     }
+    COURSE_HOLE {
+        Hole hole
+        int par
+        map drinks
+    }
     RANDOMISE {
         Hole hole
         Outcomes result
     }
 ```
 
-`Game` is the aggregate root: it owns its `Player`s, the `Pub` route, and the active twist.
+`Game` is the aggregate root: it owns its `Player`s, the `Pub` route, its course (drinks and
+pars per hole, set by the host) and the active twist. A game with no saved course falls back to
+the default in `Routes`, so par-relative ranking and the course view always resolve.
 Scores are a `Map<Hole, ScoreWithTimestamp>` per player, initialised to zero for every hole
 up to `GameConstants.MAX_HOLES`.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ scores come in.
 
 - Real-time leaderboard updates over WebSocket (STOMP)
 - Custom game creation with configurable rules
+- Host panel: per-game drinks and pars, pub route, and live events
 - QR code game invitations
 - Randomise wheel for in-game twists (double drink, half score, etc.)
 - Penalty tracking per hole

--- a/e2e/tests/create-game.spec.ts
+++ b/e2e/tests/create-game.spec.ts
@@ -25,13 +25,18 @@ test.describe('Create Game', () => {
     await expect(page).toHaveURL('/');
   });
 
-  test('route map toggle leads to the route builder page', async ({ page }) => {
+  test('route map is set up from the host panel', async ({ page }) => {
     await page.goto('/');
 
     await page.getByRole('button', { name: 'Host a Round' }).click();
     await page.locator('#create-name').fill('RouteHost');
-    await page.getByRole('switch', { name: 'Add route map' }).click();
     await page.getByRole('button', { name: 'Tee Off' }).click();
+
+    await expect(page).toHaveURL('/game');
+    await expect(page.getByRole('switch', { name: 'Add route map' })).toHaveCount(0);
+
+    await page.getByRole('link', { name: 'Host Panel' }).click();
+    await page.getByRole('link', { name: 'Set up route map' }).click();
 
     await expect(page).toHaveURL('/game/route');
     await expect(page.getByRole('heading', { name: 'Add Route Map' })).toBeVisible();

--- a/e2e/tests/host-course.spec.ts
+++ b/e2e/tests/host-course.spec.ts
@@ -1,0 +1,96 @@
+import { test, expect } from '../fixtures/test-fixtures';
+
+test.describe('Host Course Editing', () => {
+  test('host edits drinks and pars and players see the new course', async ({
+    page,
+    createGameViaApi,
+  }) => {
+    const hostSession = await createGameViaApi('CourseHost');
+
+    await page.goto('/');
+    await page.evaluate((session) => {
+      localStorage.setItem('gameCode', session.gameCode);
+      localStorage.setItem('playerId', session.playerId);
+      localStorage.setItem('playerName', session.playerName);
+    }, hostSession);
+
+    await page.goto(`/game/${hostSession.gameCode}/host`);
+
+    // Seeded from the default course until the host edits it.
+    const firstDrink = page.getByLabel('Hole 1 drink on Route A');
+    await expect(firstDrink).toHaveValue('Tequila');
+
+    await firstDrink.fill('Espresso Martini');
+    await page.getByLabel('Hole 1 par').fill('4');
+    await page.getByRole('button', { name: 'Save Drinks & Pars' }).click();
+
+    await expect(page.getByText('Saved — all players updated')).toBeVisible();
+
+    // The rules page reads the game's course, not the global default.
+    await page.goto('/how-to-play');
+    await expect(page.getByText('Espresso Martini')).toBeVisible();
+
+    // Par drives the log-score screen too.
+    await page.goto('/submit-score');
+    await expect(page.getByText(/Par 4 · how many did it take\?/)).toBeVisible();
+  });
+
+  test('host can rename a route', async ({ page, createGameViaApi }) => {
+    const hostSession = await createGameViaApi('RenameHost');
+
+    await page.goto('/');
+    await page.evaluate((session) => {
+      localStorage.setItem('gameCode', session.gameCode);
+      localStorage.setItem('playerId', session.playerId);
+      localStorage.setItem('playerName', session.playerName);
+    }, hostSession);
+
+    await page.goto(`/game/${hostSession.gameCode}/host`);
+
+    await page.getByLabel('Route 1 name').fill('Ale Trail');
+    await page.getByRole('button', { name: 'Save Drinks & Pars' }).click();
+
+    await expect(page.getByText('Saved — all players updated')).toBeVisible();
+
+    await page.goto('/how-to-play');
+    await expect(page.getByRole('columnheader', { name: 'Ale Trail' })).toBeVisible();
+  });
+
+  test('blank drink is rejected before saving', async ({ page, createGameViaApi }) => {
+    const hostSession = await createGameViaApi('ValidationHost');
+
+    await page.goto('/');
+    await page.evaluate((session) => {
+      localStorage.setItem('gameCode', session.gameCode);
+      localStorage.setItem('playerId', session.playerId);
+      localStorage.setItem('playerName', session.playerName);
+    }, hostSession);
+
+    await page.goto(`/game/${hostSession.gameCode}/host`);
+
+    await page.getByLabel('Hole 2 drink on Route A').fill('');
+    await page.getByRole('button', { name: 'Save Drinks & Pars' }).click();
+
+    await expect(page.getByText('Every route needs a drink for hole 2')).toBeVisible();
+  });
+
+  test('non-host is redirected away from the host panel', async ({
+    page,
+    createGameViaApi,
+    joinGameViaApi,
+  }) => {
+    const hostSession = await createGameViaApi('CourseHost');
+    const playerSession = await joinGameViaApi(hostSession.gameCode, 'RegularPlayer');
+
+    await page.goto('/');
+    await page.evaluate((session) => {
+      localStorage.setItem('gameCode', session.gameCode);
+      localStorage.setItem('playerId', session.playerId);
+      localStorage.setItem('playerName', session.playerName);
+    }, playerSession);
+
+    await page.goto(`/game/${hostSession.gameCode}/host`);
+
+    await expect(page.getByRole('button', { name: 'Save Drinks & Pars' })).toHaveCount(0);
+  });
+});

--- a/plans/host-panel-course.md
+++ b/plans/host-panel-course.md
@@ -1,0 +1,95 @@
+# Host Panel: Custom Drinks & Pars
+
+## Context
+The host panel (`/game/[code]/host`) already drives the pub route and built-in/custom events
+from the server. Drinks and pars are the last piece still hard-coded: `Routes` in
+`models/Domain.kt` holds a fixed nine-hole course ("Route A"/"Route B") that every game shares,
+served from `GET /api/v1/config/routes` and used for par-relative ranking. A host cannot change
+what players drink or what each hole is worth.
+
+This makes the course per-game and host-editable, and moves route-map setup out of the create
+form so the host panel is the single place a game is configured.
+
+Decisions (confirmed):
+- **Keep named routes.** A course has one or more named routes (e.g. "Route A"/"Route B"), each
+  with a drink per hole, plus a par shared by all routes on that hole. Same `drinks: Map<name, drink>`
+  shape the API and `RoutesTable` already use.
+- **Editable any time during an active game.** Saving broadcasts the new game state over STOMP
+  like events do, so a par change re-ranks the leaderboard live. Editing a completed game is rejected.
+- **Remove the "Add route map" toggle from the create form.** Hosts land on the leaderboard and
+  configure everything from the host panel.
+- Functional pass only; host panel layout/design is a separate session.
+
+## Data model
+New table, mirroring `pubs` (keyed by game + hole, cascade-deleted with the game):
+
+```sql
+CREATE TABLE game_holes (
+    game_id BLOB NOT NULL,
+    hole    INT  NOT NULL,
+    par     INT  NOT NULL,
+    drinks  TEXT NOT NULL,           -- ordered JSON object: {"Route A":"Tequila","Route B":"Sambuca"}
+    PRIMARY KEY (game_id, hole),
+    CONSTRAINT fk_game_hole_game FOREIGN KEY (game_id) REFERENCES games(id) ON DELETE CASCADE
+);
+```
+
+`drinks` is stored as JSON rather than a second table: it is always read and written whole with
+the game, key order carries column order for the table view, and `games.route_geometry` sets the
+precedent for JSON-in-column here.
+
+Domain: `Game` gains `holes: List<CourseHole>`, where
+`CourseHole(hole: Hole, par: Int, drinks: Map<String, String>)`. The course lives inside the
+`Game` aggregate (like `pubs`), so it rides the existing optimistic-lock and broadcast path and
+needs no new repository. `holes` is empty for games created before this change; `Game.course()`
+falls back to `Routes.defaultCourse`, so old games keep today's behaviour and every response is
+populated.
+
+## API
+- `PUT /api/v1/games/{gameCode}/holes` — host only, replaces the whole course, returns the updated
+  `GameStateResponse`. Body reuses the hole shape from the response, so the client can round-trip
+  what it read:
+  ```json
+  { "holes": [ { "hole": 1, "par": 1, "drinks": { "Route A": "Tequila", "Route B": "Sambuca" } } ] }
+  ```
+- `GameStateResponse` gains `holes: [{ hole, par, drinks }]`. Pars and drinks then arrive with game
+  state over REST *and* the WebSocket, so no client needs a separate fetch and edits land live.
+- `parRelative` in `GameStateResponse` uses the game's own pars instead of `Routes.par(hole)`.
+- `GET /api/v1/config/routes` is unchanged — it stays the default course/template, used by
+  `/how-to-play` when the visitor is not in a game.
+
+Validation (`InvalidCourseFailure` → 400):
+- exactly `GameConstants.MAX_HOLES` holes, each of 1..9 exactly once
+- par 1..10
+- 1..4 routes; names trimmed, non-blank, ≤ 40 chars, unique case-insensitively
+- every hole carries the same route names; order is taken from the first hole and applied to all
+- drink names non-blank, ≤ 100 chars
+
+Reuses existing failures: non-host → `NotHostPlayerFailure` (403), completed game →
+`GameAlreadyCompletedFailure` (409), unknown game → 404.
+
+## Frontend
+- `lib/types.ts`: `GameState.holes: RouteHole[]`; `lib/api.ts`: `setHoles(gameCode, playerId, holes)`.
+- `components/CourseEditor.tsx` (new): nine rows of par + one drink field per route, add/rename/remove
+  a route, save/reset. Seeded from `gameState.holes`. Plain, functional styling for now.
+- Host panel: new "Drinks & Pars" section wrapping `CourseEditor`; keeps the existing route-map link.
+- `app/game/page.tsx` and `app/submit-score/page.tsx`: take pars from game state (`holes`) and drop
+  their `getRoutes()` calls and the `DEFAULT_PARS` copy of the backend config.
+- `app/how-to-play/page.tsx`: show the current game's course when a game code is stored, falling back
+  to `getRoutes()` otherwise — this is where players read the drinks list.
+- `components/CreateGameForm.tsx`: delete the toggle and always navigate to `/game`.
+
+## Tests
+- Backend `GameServiceTest`: happy path, non-host, completed game, and each validation rule;
+  par-relative ranking against custom pars.
+- `GameRepositoryContract`: course round-trips (both JPA and Fake).
+- OpenAPI approval file regenerated for the new endpoint and response field.
+- Frontend: `CourseEditor.test.tsx`; update `how-to-play` page test for the game-course path.
+- E2E: replace the create-form toggle test in `create-game.spec.ts` with the host-panel entry point;
+  new spec for editing the course and seeing it on the rules page.
+
+## Out of scope
+- Host panel layout/visual design (next session).
+- Showing the hole's drink on the log-score screen — worth doing, but it is a design call.
+- Per-player route assignment (which of Route A/B a player is drinking) — still player-managed.
+- Variable hole counts; `MAX_HOLES` stays 9.


### PR DESCRIPTION
Drinks and pars were the last hard-coded piece of the game: a single `Routes` config shared by every game, served from `/api/v1/config/routes` and used for par-relative ranking. A host could set a pub route and trigger events, but never change what players drink or what a hole is worth. This makes the course per-game and editable from the host panel, and moves route-map setup out of the create form so the host panel is the single place a game is configured.

Scoped in `plans/host-panel-course.md`. Functional pass only — host panel layout/design is a separate session.

## Decisions

- **Named routes kept.** A course has 1–4 named routes (e.g. Route A / Route B), each with a drink per hole, plus a par shared by all routes on that hole — the same `drinks: Map<name, drink>` shape the API and `RoutesTable` already render.
- **Editable any time during an active game.** Saving broadcasts new game state over STOMP like events do, so a par change re-ranks the leaderboard live for everyone. Editing a completed game is rejected.
- **Course lives in the `Game` aggregate** (like `pubs`), so it rides the existing optimistic-lock and broadcast path and needs no new repository.

## Backend

- `V10__game_holes.sql`: `game_holes(game_id, hole, par, drinks)`, keyed and cascade-deleted like `pubs`. `drinks` is an ordered JSON object — it is always read/written whole with the game, key order carries the route display order, and `games.route_geometry` sets the JSON-in-column precedent.
- `CourseHole` domain type; `Game.holes` plus `course()` / `par(hole)`. Games created before this have an empty course and fall back to `Routes.defaultCourse`, so nothing changes for them.
- `PUT /api/v1/games/{gameCode}/holes` — host only, replaces the whole course, returns the updated `GameStateResponse`. The request reuses the response's hole shape, so a client can round-trip what it read.
- `GameStateResponse` gains `holes`, always populated. Pars and drinks now arrive with game state over REST *and* WebSocket, so no client needs a separate fetch. `parRelative` uses the game's own pars.
- Validation → `InvalidCourseFailure` (400): all nine holes exactly once, par 1–10, 1–4 routes with unique non-blank names ≤40 chars, every hole covering the same routes, drinks non-blank ≤100 chars. Route order is taken from hole 1 and normalised across the course. Non-host → 403, completed game → 409.
- `GET /api/v1/config/routes` is unchanged — it stays the default course for visitors without a game.

## Frontend

- New `CourseEditor` component in a "Drinks & Pars" host panel section: a drink field per route per hole, par per hole, add/rename/remove a route, save/reset. Renaming a route keeps its column. Plain styling on existing primitives.
- Leaderboard and log-score pages take pars from game state, dropping their `getRoutes()` calls and the `DEFAULT_PARS` duplicate of backend config.
- Rules page shows the current game's course when a game code is stored, falling back to the default course otherwise — this is where players read the drinks list.
- `CreateGameForm` loses the "Add route map" toggle and always lands on `/game`.

## Testing

- `GameServiceTest`: happy path, ordering/trimming normalisation, host and completed-game rejections, every validation rule, and par-relative ranking against custom pars.
- `GameRepositoryContract`: course round-trips (including route order) and the default-course fallback, so the JPA adapter and the Fake stay honest.
- OpenAPI approval file regenerated for the new endpoint and response field.
- `CourseEditor.test.tsx` (14 tests) and new rules-page tests for the game-course path.
- E2E: new `host-course.spec.ts`; the create-form toggle test is replaced by the host-panel route-map entry point.
- Gates run locally: backend `test` + `ktlintCheck` green, frontend 409 tests + lint green, full Playwright suite green on chromium (44) and the new specs green on mobile-chrome.

## Notes

- Showing the hole's drink on the log-score screen is deliberately left out — it's a design call for the follow-up session.
- Per-player route assignment (which of A/B a player is drinking) is unchanged and still player-managed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UpvDdovVtBMy6zQdjpgNKH)_