### PR TITLE
Course-driven rules text and mobile fixes for the course editor

### DIFF
--- a/apps/frontend/app/how-to-play/page.test.tsx
+++ b/apps/frontend/app/how-to-play/page.test.tsx
@@ -133,6 +133,66 @@ describe('HowToPlayPage', () => {
     });
   });
 
+  describe('route rule', () => {
+    test('should use generic wording before the course loads', () => {
+      mockGetRoutes.mockImplementation(() => new Promise(() => {}));
+      render(<HowToPlayPage />);
+
+      expect(
+        screen.getByText('Pick your route at the start. No switching mid-game.')
+      ).toBeInTheDocument();
+    });
+
+    test("should name the course's routes once loaded", async () => {
+      mockGetRoutes.mockImplementation(() => Promise.resolve({
+        holes: [
+          {
+            hole: 1,
+            par: 1,
+            drinks: {
+              'Ale Trail': 'Beer',
+              'Spirit Run': 'Vodka',
+              'Wine Walk': 'Merlot',
+              'Soft Stroll': 'Lemonade',
+            },
+          },
+        ],
+      }));
+      render(<HowToPlayPage />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            'Pick Ale Trail, Spirit Run, Wine Walk, or Soft Stroll at the start. No switching mid-game.'
+          )
+        ).toBeInTheDocument();
+      });
+    });
+
+    test('should drop the choice when the course has one route', async () => {
+      mockGetGameCode.mockImplementation(() => 'ACE007');
+      render(<HowToPlayPage />);
+
+      await waitFor(() => {
+        expect(
+          screen.getByText('Everyone plays Ale Trail. One route, no switching mid-game.')
+        ).toBeInTheDocument();
+      });
+    });
+
+    test('should keep generic wording when the course fails to load', async () => {
+      mockGetRoutes.mockImplementation(() => Promise.reject(new Error('Network error')));
+      render(<HowToPlayPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Skip')).toBeInTheDocument();
+      });
+      expect(
+        screen.getByText('Pick your route at the start. No switching mid-game.')
+      ).toBeInTheDocument();
+    });
+  });
+
   describe('game course', () => {
     test("should render the game's own course when in a game", async () => {
       mockGetGameCode.mockImplementation(() => 'ACE007');

--- a/apps/frontend/app/how-to-play/page.tsx
+++ b/apps/frontend/app/how-to-play/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { RULES } from '@/lib/constants';
+import { buildRules } from '@/lib/constants';
 import { getPenaltyOptions, getRoutes, getGameState, PenaltyOption } from '@/lib/api';
 import { PENALTY_EMOJI_MAP, PenaltyType, RouteHole } from '@/lib/types';
 import { useLocalStorage } from '@/hooks/useLocalStorage';
@@ -75,6 +75,10 @@ export default function HowToPlayPage() {
   const [routesError, setRoutesError] = useState(false);
   const { getGameCode } = useLocalStorage();
 
+  // Route names come from the course itself, so the rules name the host's
+  // routes. Before the course loads this falls back to generic wording.
+  const rules = buildRules(holes.length > 0 ? Object.keys(holes[0].drinks) : []);
+
   useEffect(() => {
     getPenaltyOptions()
       .then((response) => setPenalties(response.penalties))
@@ -112,7 +116,7 @@ export default function HowToPlayPage() {
         <Card as="section" padding="lg" rounded="lg">
           <h2 className="text-[var(--color-text)] font-bold text-[15px] mb-3.5">How It Works</h2>
           <ol className="space-y-3 mb-6">
-            {RULES.map((rule, index) => (
+            {rules.map((rule, index) => (
               <li key={index} className="flex gap-2.5 text-[13.5px] leading-normal text-[var(--color-text-secondary)]">
                 <span className="font-display text-sm text-[var(--color-primary)]">{index + 1}</span>
                 <span>{rule}</span>

--- a/apps/frontend/app/layout.tsx
+++ b/apps/frontend/app/layout.tsx
@@ -65,6 +65,12 @@ export const metadata: Metadata = {
 export const viewport: Viewport = {
   viewportFit: "cover",
   themeColor: "#0d1410",
+  // iOS Safari zooms the page in whenever a focused field's text is under 16px, which
+  // this app's compact inputs (the inline course editor especially) are by design.
+  // Capping the scale stops that lurch on focus; pinch-to-zoom is still a user gesture
+  // iOS honours, and user-scalable stays on for assistive zoom settings.
+  maximumScale: 1,
+  userScalable: true,
 };
 
 export default function RootLayout({

--- a/apps/frontend/components/CourseEditor.test.tsx
+++ b/apps/frontend/components/CourseEditor.test.tsx
@@ -11,6 +11,13 @@ const holes: RouteHole[] = [
 
 const save = () => screen.getByRole('button', { name: 'SAVE COURSE' });
 
+/** The par stepper reads as a group; its value is the text inside. */
+const par = (hole: number) => screen.getByRole('group', { name: `Hole ${hole} par` });
+const stepUp = (hole: number) =>
+  screen.getByRole('button', { name: `Increase hole ${hole} par` });
+const stepDown = (hole: number) =>
+  screen.getByRole('button', { name: `Decrease hole ${hole} par` });
+
 /** Tap a chip to view that route; tap the selected one again to rename it. */
 async function selectRoute(user: ReturnType<typeof userEvent.setup>, name: string) {
   await user.click(screen.getByRole('button', { name }));
@@ -37,7 +44,7 @@ describe('CourseEditor', () => {
 
       expect(screen.getByLabelText('Hole 1 drink on Route A')).toHaveValue('Tequila');
       expect(screen.getByLabelText('Hole 2 drink on Route A')).toHaveValue('Beer');
-      expect(screen.getByLabelText('Hole 2 par')).toHaveValue(3);
+      expect(par(2)).toHaveTextContent('3');
       // Only the selected route's column is shown.
       expect(screen.queryByLabelText('Hole 1 drink on Route B')).not.toBeInTheDocument();
     });
@@ -49,7 +56,7 @@ describe('CourseEditor', () => {
       await selectRoute(user, 'Route B');
 
       expect(screen.getByLabelText('Hole 1 drink on Route B')).toHaveValue('Sambuca');
-      expect(screen.getByLabelText('Hole 2 par')).toHaveValue(3);
+      expect(par(2)).toHaveTextContent('3');
       expect(screen.queryByLabelText('Hole 1 drink on Route A')).not.toBeInTheDocument();
     });
 
@@ -208,17 +215,50 @@ describe('CourseEditor', () => {
       expect(onSave).not.toHaveBeenCalled();
     });
 
-    test('should reject a par outside the allowed range', async () => {
+    test('should step par up and down and save the new value', async () => {
       const user = userEvent.setup();
       const onSave = mock(async () => {});
       render(<CourseEditor holes={holes} onSave={onSave} />);
 
-      await user.clear(screen.getByLabelText('Hole 1 par'));
-      await user.type(screen.getByLabelText('Hole 1 par'), '11');
+      await user.click(stepUp(1));
+      await user.click(stepUp(1));
+      await user.click(stepDown(2));
+      expect(par(1)).toHaveTextContent('3');
+      expect(par(2)).toHaveTextContent('2');
+
       await user.click(save());
 
-      expect(screen.getByText(/par for hole 1 must be between 1 and 10/i)).toBeInTheDocument();
-      expect(onSave).not.toHaveBeenCalled();
+      await waitFor(() => {
+        expect(onSave).toHaveBeenCalledWith([
+          { hole: 1, par: 3, drinks: { 'Route A': 'Tequila', 'Route B': 'Sambuca' } },
+          { hole: 2, par: 2, drinks: { 'Route A': 'Beer', 'Route B': 'Vodka' } },
+        ]);
+      });
+    });
+
+    test('should stop stepping at the allowed range', async () => {
+      const user = userEvent.setup();
+      render(<CourseEditor holes={holes} onSave={mock(async () => {})} />);
+
+      // Hole 1 starts at the minimum par of 1.
+      expect(stepDown(1)).toBeDisabled();
+
+      for (let i = 0; i < 9; i++) {
+        await user.click(stepUp(1));
+      }
+
+      expect(par(1)).toHaveTextContent('10');
+      expect(stepUp(1)).toBeDisabled();
+    });
+
+    test('should leave par alone when a drink is edited', async () => {
+      const user = userEvent.setup();
+      render(<CourseEditor holes={holes} onSave={mock(async () => {})} />);
+
+      await user.clear(screen.getByLabelText('Hole 1 drink on Route A'));
+      await user.type(screen.getByLabelText('Hole 1 drink on Route A'), 'Cider');
+
+      expect(par(1)).toHaveTextContent('1');
     });
   });
 

--- a/apps/frontend/components/CourseEditor.tsx
+++ b/apps/frontend/components/CourseEditor.tsx
@@ -93,6 +93,52 @@ function PencilIcon() {
   );
 }
 
+interface ParStepperProps {
+  hole: number;
+  par: number;
+  onChange: (par: number) => void;
+  disabled: boolean;
+}
+
+/**
+ * Par is a stepper rather than a number field: a 34px-wide input was a fiddly tap target,
+ * and every edit opened the numeric keyboard over the very list being edited. Stepping
+ * also keeps par inside MIN_PAR..MAX_PAR by construction instead of at save time.
+ */
+function ParStepper({ hole, par, onChange, disabled }: ParStepperProps) {
+  const buttonClasses =
+    'flex h-8 w-8 items-center justify-center rounded-lg border border-[var(--color-border-subtle)] bg-[var(--color-bg)] text-sm leading-none text-[var(--color-text-secondary)] hover:text-[var(--color-accent)] disabled:opacity-40';
+
+  return (
+    <div className="flex items-center gap-1" role="group" aria-label={`Hole ${hole} par`}>
+      <button
+        type="button"
+        onClick={() => onChange(par - 1)}
+        disabled={disabled || par <= MIN_PAR}
+        aria-label={`Decrease hole ${hole} par`}
+        className={buttonClasses}
+      >
+        <span aria-hidden="true">−</span>
+      </button>
+      <span
+        className="w-4 text-center text-xs font-bold text-[var(--color-accent)]"
+        aria-live="polite"
+      >
+        {par}
+      </span>
+      <button
+        type="button"
+        onClick={() => onChange(par + 1)}
+        disabled={disabled || par >= MAX_PAR}
+        aria-label={`Increase hole ${hole} par`}
+        className={buttonClasses}
+      >
+        <span aria-hidden="true">+</span>
+      </button>
+    </div>
+  );
+}
+
 export function CourseEditor({ holes, onSave, disabled = false }: CourseEditorProps) {
   const initial = useMemo(() => toDraft(holes), [holes]);
   // The draft deliberately survives incoming game-state updates so an edit in
@@ -150,9 +196,10 @@ export function CourseEditor({ holes, onSave, disabled = false }: CourseEditorPr
   };
 
   const setPar = (holeIndex: number, par: number) => {
+    const clamped = Math.min(MAX_PAR, Math.max(MIN_PAR, par));
     update({
       ...draft,
-      holes: draft.holes.map((hole, i) => (i === holeIndex ? { ...hole, par } : hole)),
+      holes: draft.holes.map((hole, i) => (i === holeIndex ? { ...hole, par: clamped } : hole)),
     });
   };
 
@@ -279,17 +326,17 @@ export function CourseEditor({ holes, onSave, disabled = false }: CourseEditorPr
           )}
         </div>
 
-        <div className="grid grid-cols-[16px_1fr_34px] gap-x-2.5 border-b border-[var(--color-border)] pb-1.5 text-[9.5px] uppercase tracking-[0.05em] text-[var(--color-text-faint)]">
+        <div className="grid grid-cols-[16px_1fr_88px] gap-x-2.5 border-b border-[var(--color-border)] pb-1.5 text-[9.5px] uppercase tracking-[0.05em] text-[var(--color-text-faint)]">
           <span />
           <span className="text-[var(--color-accent)]">{selectedRouteName} — drink names</span>
-          <span className="text-right text-[var(--color-accent)]">Par</span>
+          <span className="text-center text-[var(--color-accent)]">Par</span>
         </div>
 
         <ul className="flex-1 overflow-y-auto">
           {draft.holes.map((hole, holeIndex) => (
             <li
               key={hole.hole}
-              className="grid grid-cols-[16px_1fr_34px] items-center gap-x-2.5 border-b border-[var(--color-border-subtle)]/60 py-1.5 last:border-b-0"
+              className="grid grid-cols-[16px_1fr_88px] items-center gap-x-2.5 border-b border-[var(--color-border-subtle)]/60 py-1.5 last:border-b-0"
             >
               <span className="font-display text-xs text-[var(--color-primary)]" aria-hidden="true">
                 {hole.hole}
@@ -303,15 +350,11 @@ export function CourseEditor({ holes, onSave, disabled = false }: CourseEditorPr
                 aria-label={`Hole ${hole.hole} drink on ${selectedRouteName || `route ${selectedRoute + 1}`}`}
                 className="min-w-0 border-none bg-transparent py-1 text-xs text-[var(--color-text-secondary)] placeholder:text-[var(--color-text-faint)] focus:outline-none focus:text-[var(--color-text)] disabled:opacity-60"
               />
-              <input
-                type="number"
-                min={MIN_PAR}
-                max={MAX_PAR}
-                value={hole.par}
-                onChange={(e) => setPar(holeIndex, Number(e.target.value))}
+              <ParStepper
+                hole={hole.hole}
+                par={hole.par}
+                onChange={(par) => setPar(holeIndex, par)}
                 disabled={busy}
-                aria-label={`Hole ${hole.hole} par`}
-                className="w-full border-none bg-transparent py-1 text-right text-xs font-bold text-[var(--color-accent)] [appearance:textfield] focus:outline-none disabled:opacity-60 [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
               />
             </li>
           ))}

--- a/apps/frontend/components/ui/BottomSheet.test.tsx
+++ b/apps/frontend/components/ui/BottomSheet.test.tsx
@@ -1,4 +1,5 @@
 import { describe, test, expect, mock } from 'bun:test';
+import { useState } from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { BottomSheet } from './BottomSheet';
@@ -72,9 +73,48 @@ describe('BottomSheet', () => {
     expect(onClose).not.toHaveBeenCalled();
   });
 
-  test('should move focus into the sheet on open', () => {
+  test('should move focus onto the sheet surface on open', () => {
     renderSheet();
 
-    expect(document.activeElement).toBe(screen.getByLabelText('Route name'));
+    const surface = screen.getByRole('heading', { name: 'New Route' }).parentElement;
+    expect(surface).toHaveAttribute('tabindex', '-1');
+    expect(document.activeElement).toBe(surface);
+  });
+
+  test('should not focus a text field on open', () => {
+    renderSheet();
+
+    expect(document.activeElement).not.toBe(screen.getByLabelText('Route name'));
+  });
+
+  test('should leave focus in a field the user has tapped into', async () => {
+    const user = userEvent.setup();
+    // Mirrors real callers: state changes on every keystroke and `onClose` is an inline
+    // closure, so the sheet re-renders with a new prop identity as the user types.
+    function StatefulSheet() {
+      const [value, setValue] = useState('');
+      return (
+        <BottomSheet title="New Route" onClose={() => {}}>
+          <input aria-label="Route name" value={value} onChange={(e) => setValue(e.target.value)} />
+        </BottomSheet>
+      );
+    }
+    render(<StatefulSheet />);
+
+    const input = screen.getByLabelText('Route name');
+    await user.type(input, 'Wine Walk');
+
+    expect(input).toHaveValue('Wine Walk');
+    expect(document.activeElement).toBe(input);
+  });
+
+  test('should focus the first control when the sheet opens with no text field', () => {
+    render(
+      <BottomSheet title="Pick one" onClose={mock(() => {})}>
+        <button type="button">Option A</button>
+      </BottomSheet>
+    );
+
+    expect(document.activeElement).toBe(screen.getByRole('button', { name: 'Option A' }));
   });
 });

--- a/apps/frontend/components/ui/BottomSheet.tsx
+++ b/apps/frontend/components/ui/BottomSheet.tsx
@@ -51,6 +51,9 @@ export function BottomSheet({
     >
       <motion.div
         ref={containerRef}
+        // Focus target on open, so the sheet is announced without a text field grabbing
+        // focus and opening the keyboard.
+        tabIndex={-1}
         variants={slideFromBottomVariants}
         initial="initial"
         animate="animate"

--- a/apps/frontend/hooks/useDialogDismiss.ts
+++ b/apps/frontend/hooks/useDialogDismiss.ts
@@ -7,6 +7,12 @@ import { useEffect, useRef, type RefObject } from 'react';
 const FOCUSABLE_SELECTOR =
   'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
+// Fields that pop the on-screen keyboard the moment they take focus. A dialog never
+// auto-focuses one - on a phone that covers half the sheet before the user has decided
+// to type - so focus lands on the dialog surface instead and typing starts on a tap.
+const TEXT_ENTRY_SELECTOR =
+  'textarea, input:not([type="button"]):not([type="submit"]):not([type="reset"]):not([type="checkbox"]):not([type="radio"])';
+
 interface UseDialogDismissOptions {
   /** Called on Escape and on a click that lands on the backdrop itself. */
   onDismiss: () => void;
@@ -34,15 +40,25 @@ export function useDialogDismiss<Container extends HTMLElement = HTMLDivElement>
 }: UseDialogDismissOptions): UseDialogDismissResult<Container> {
   const containerRef = useRef<Container>(null);
 
+  // Mount only: re-running this on every render would yank focus back out of whatever
+  // the user is typing in, since callers pass inline `onDismiss` closures.
   useEffect(() => {
-    const focusables = () =>
-      Array.from(containerRef.current?.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR) ?? []);
+    const firstFocusable = containerRef.current?.querySelector<HTMLElement>(FOCUSABLE_SELECTOR);
 
     if (initialFocusRef?.current) {
       initialFocusRef.current.focus();
+    } else if (firstFocusable && !firstFocusable.matches(TEXT_ENTRY_SELECTOR)) {
+      firstFocusable.focus();
     } else {
-      focusables()[0]?.focus();
+      // Needs tabindex="-1" on the surface, which every dialog here sets.
+      containerRef.current?.focus();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    const focusables = () =>
+      Array.from(containerRef.current?.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR) ?? []);
 
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
@@ -56,7 +72,11 @@ export function useDialogDismiss<Container extends HTMLElement = HTMLDivElement>
       const first = elements[0];
       const last = elements[elements.length - 1];
 
-      if (event.shiftKey && document.activeElement === first) {
+      // Shift+Tab off the surface itself wraps to the end, same as off the first element.
+      const atStart =
+        document.activeElement === first || document.activeElement === containerRef.current;
+
+      if (event.shiftKey && atStart) {
         event.preventDefault();
         last?.focus();
       } else if (!event.shiftKey && document.activeElement === last) {
@@ -67,7 +87,7 @@ export function useDialogDismiss<Container extends HTMLElement = HTMLDivElement>
 
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [onDismiss, locked, initialFocusRef]);
+  }, [onDismiss, locked]);
 
   const onBackdropClick = (event: React.MouseEvent) => {
     if (event.target === event.currentTarget && !locked) {

--- a/apps/frontend/lib/constants.test.ts
+++ b/apps/frontend/lib/constants.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'bun:test';
-import { RULES } from './constants';
+import { RULES, buildRules, routeRule } from './constants';
 
 describe('RULES', () => {
   test('should export an array of 4 rules', () => {
@@ -12,5 +12,69 @@ describe('RULES', () => {
       expect(rule.length).toBeGreaterThan(0);
     });
   });
+
+  test('should use generic route wording when no routes are known', () => {
+    expect(RULES[1]).toBe('Pick your route at the start. No switching mid-game.');
+  });
 });
 
+describe('routeRule', () => {
+  test('should fall back to generic wording for no routes', () => {
+    expect(routeRule([])).toBe('Pick your route at the start. No switching mid-game.');
+  });
+
+  test('should ignore blank route names', () => {
+    expect(routeRule(['  ', ''])).toBe('Pick your route at the start. No switching mid-game.');
+  });
+
+  test('should drop the choice for a single route', () => {
+    expect(routeRule(['Ale Trail'])).toBe(
+      'Everyone plays Ale Trail. One route, no switching mid-game.'
+    );
+  });
+
+  test('should join two routes with "or"', () => {
+    expect(routeRule(['Route A', 'Route B'])).toBe(
+      'Pick Route A or Route B at the start. No switching mid-game.'
+    );
+  });
+
+  test('should comma-join three routes', () => {
+    expect(routeRule(['Route A', 'Route B', 'Route C'])).toBe(
+      'Pick Route A, Route B, or Route C at the start. No switching mid-game.'
+    );
+  });
+
+  test('should comma-join four custom-named routes', () => {
+    expect(routeRule(['Ale Trail', 'Spirit Run', 'Wine Walk', 'Soft Stroll'])).toBe(
+      'Pick Ale Trail, Spirit Run, Wine Walk, or Soft Stroll at the start. No switching mid-game.'
+    );
+  });
+
+  test('should trim surrounding whitespace from names', () => {
+    expect(routeRule([' Route A ', 'Route B'])).toBe(
+      'Pick Route A or Route B at the start. No switching mid-game.'
+    );
+  });
+});
+
+describe('buildRules', () => {
+  test('should always return 4 rules', () => {
+    expect(buildRules(['Route A', 'Route B'])).toHaveLength(4);
+    expect(buildRules(['Only Route'])).toHaveLength(4);
+  });
+
+  test('should place the route rule second', () => {
+    expect(buildRules(['Ale Trail', 'Spirit Run'])[1]).toBe(
+      routeRule(['Ale Trail', 'Spirit Run'])
+    );
+  });
+
+  test('should keep the other rules unchanged', () => {
+    const rules = buildRules(['Ale Trail', 'Spirit Run']);
+
+    expect(rules[0]).toBe(RULES[0]);
+    expect(rules[2]).toBe(RULES[2]);
+    expect(rules[3]).toBe(RULES[3]);
+  });
+});

--- a/apps/frontend/lib/constants.ts
+++ b/apps/frontend/lib/constants.ts
@@ -1,6 +1,36 @@
-export const RULES = [
-  'Finish your drink in as few sips as possible. Your score = your sips.',
-  'Pick Route A or B at the start. No switching mid-game.',
-  'Use Randomise once per game to swap a drink for something random.',
-  'Lowest total score wins. May the best drinker take home the glory.',
-];
+/** Joins names into a natural "A, B, or C" phrase. */
+function orList(names: string[]): string {
+  if (names.length === 1) return names[0];
+  if (names.length === 2) return `${names[0]} or ${names[1]}`;
+  return `${names.slice(0, -1).join(', ')}, or ${names[names.length - 1]}`;
+}
+
+/**
+ * The route rule for a course. Hosts name their own routes and can run
+ * anywhere from one to four of them, so the wording follows the course
+ * rather than assuming the old "Route A or B" default.
+ */
+export function routeRule(routeNames: string[]): string {
+  const names = routeNames.map((name) => name.trim()).filter((name) => name.length > 0);
+
+  if (names.length === 0) {
+    return 'Pick your route at the start. No switching mid-game.';
+  }
+  if (names.length === 1) {
+    return `Everyone plays ${names[0]}. One route, no switching mid-game.`;
+  }
+  return `Pick ${orList(names)} at the start. No switching mid-game.`;
+}
+
+/** The rules for a course, with the route rule named after that course's routes. */
+export function buildRules(routeNames: string[] = []): string[] {
+  return [
+    'Finish your drink in as few sips as possible. Your score = your sips.',
+    routeRule(routeNames),
+    'Use Randomise once per game to swap a drink for something random.',
+    'Lowest total score wins. May the best drinker take home the glory.',
+  ];
+}
+
+/** Generic rules, used before a course has loaded. */
+export const RULES = buildRules();

--- a/e2e/tests/host-course.spec.ts
+++ b/e2e/tests/host-course.spec.ts
@@ -1,6 +1,13 @@
 import { test, expect } from '../fixtures/test-fixtures';
 import type { Page } from '@playwright/test';
 
+/** The par stepper's current value, scoped inside the stepper's own group. */
+function parValue(page: Page, hole: number, par: number) {
+  return page
+    .getByRole('group', { name: `Hole ${hole} par` })
+    .getByText(String(par), { exact: true });
+}
+
 /** The panel opens on Events; course setup lives behind the second tab. */
 async function openCourseTab(page: Page) {
   await page.getByRole('button', { name: 'Course' }).click();
@@ -29,7 +36,12 @@ test.describe('Host Course Editing', () => {
     await expect(firstDrink).toHaveValue('Tequila');
 
     await firstDrink.fill('Espresso Martini');
-    await page.getByLabel('Hole 1 par').fill('4');
+    // Par steps up rather than being typed: hole 1 starts at par 1.
+    const stepUp = page.getByRole('button', { name: 'Increase hole 1 par' });
+    await stepUp.click();
+    await stepUp.click();
+    await stepUp.click();
+    await expect(parValue(page, 1, 4)).toBeVisible();
     await page.getByRole('button', { name: 'SAVE COURSE' }).click();
 
     await expect(page.getByText('Saved — all players updated')).toBeVisible();
@@ -60,14 +72,14 @@ test.describe('Host Course Editing', () => {
     await openCourseTab(page);
 
     await expect(page.getByLabel('Hole 1 drink on Route A')).toHaveValue('Tequila');
-    await expect(page.getByLabel('Hole 1 par')).toHaveValue('1');
+    await expect(parValue(page, 1, 1)).toBeVisible();
 
     await page.getByRole('button', { name: 'Route B', exact: true }).click();
 
     await expect(page.getByLabel('Hole 1 drink on Route B')).toHaveValue('Sambuca');
     await expect(page.getByLabel('Hole 1 drink on Route A')).toHaveCount(0);
     // Par is game-level state, so it is the same whichever route is shown.
-    await expect(page.getByLabel('Hole 1 par')).toHaveValue('1');
+    await expect(parValue(page, 1, 1)).toBeVisible();
   });
 
   test('host can rename a route by tapping the selected chip again', async ({


### PR DESCRIPTION
## Rules follow the course's own routes

The rules page still told players to "Pick Route A or B" even though courses are host-driven and can carry one to four routes with host-chosen names. The route rule is now built from the course that's on screen.

- `lib/constants.ts`: `RULES` becomes `buildRules(routeNames)` + `routeRule(routeNames)`. Wording follows the course:
  - none known (still loading, or the fetch failed) → "Pick your route at the start. No switching mid-game."
  - one route → "Everyone plays Ale Trail. One route, no switching mid-game."
  - two → "Pick Route A or Route B at the start. …"
  - three or four → "Pick Ale Trail, Spirit Run, Wine Walk, or Soft Stroll at the start. …"
- `app/how-to-play/page.tsx` derives the names from the loaded course (the game's own course when in a game, the default otherwise), so it reflects any renames the host made.
- Blank names are dropped and names are trimmed, so a half-finished route in the editor can't produce "Pick  or Route B".

## Par is a stepper, not a number field

Par was a 34px-wide `type="number"` input — a poor tap target on a phone, and every edit opened the numeric keyboard over the list being edited. Clearing it went through `Number('')`, so the field jumped to `0` and had to be selected before a new value could be typed.

It's now a −/+ stepper with 32px targets, disabled at the ends of the 1–10 range, so par stays in range by construction rather than only at save-time validation. `setPar` clamps as well. The par column grows from 34px to 88px, which the row has room for.

## Bottom sheets no longer open the keyboard on their own

`useDialogDismiss` focused the first focusable element, which in the New Route and Custom Event sheets is a text field — on a phone the keyboard covered half the sheet before the user had decided to type. Focus now lands on the sheet surface (`tabIndex={-1}`), so the dialog is still announced and the focus trap still works, but typing starts on a tap. Sheets whose first control isn't a text field (and the modals that pass `initialFocusRef`) are unchanged.

While fixing that: the initial-focus effect now runs on mount only. It previously listed `onDismiss` in its deps, which callers pass as an inline closure, so it re-ran on every render and would have pulled focus back out of the field mid-typing.

## iOS zoom on inline editing

iOS Safari zooms the page whenever a focused field's text is under 16px, which the compact inputs are by design — most noticeable renaming a route inline in the course editor. `viewport.maximumScale = 1` stops the lurch without touching the type scale. Trade-off worth flagging: `user-scalable` stays on and iOS still honours pinch-to-zoom as a user gesture, but Android Chrome does apply the cap, so pinch zoom there is limited unless the system "force enable zoom" setting is on. The alternative — flooring every input at 16px on touch — would have visibly reshaped the dense course-editor grid.

## Testing

- `bun test` in `apps/frontend`: 468 pass, 0 fail.
- New coverage: `routeRule`/`buildRules` for one to four routes, blanks and trimming; how-to-play for the loading, loaded, single-route and fetch-failure wordings; CourseEditor for stepping par up and down, saving the stepped value, and the stepper disabling at 1 and 10; BottomSheet for surface focus, no text-field focus, focus staying put while typing, and first-control focus when there's no text field.
- `e2e/tests/host-course.spec.ts` updated to step par rather than fill it; e2e typechecks, but the suite itself runs in CI.
- `bun run lint` clean; `tsc --noEmit` clean for source files (the pre-existing `bun:test` resolution errors in test files are unchanged).
- Not verified on a physical iOS device — the viewport change is the standard fix but worth a quick check on hardware before merging.