### PR TITLE
Fix missing favicon by explicitly declaring icon metadata

### DIFF
--- a/apps/frontend/app/layout.tsx
+++ b/apps/frontend/app/layout.tsx
@@ -58,6 +58,10 @@ export const metadata: Metadata = {
     title: "Pub Golf",
   },
   icons: {
+    icon: [
+      { url: "/icon-192.png", sizes: "192x192", type: "image/png" },
+      { url: "/icon-512.png", sizes: "512x512", type: "image/png" },
+    ],
     apple: "/apple-touch-icon.png",
   },
 };


### PR DESCRIPTION
## Summary
- `app/layout.tsx` set `icons.apple` manually, which short-circuits Next.js's file-based icon merging (it only merges the auto-detected `app/icon.png` favicon when `icons` is still unset).
- Result: no `<link rel="icon">` was ever emitted, so browsers fell back to requesting `/favicon.ico`, got a 404, and showed the default tab icon.
- Fix: explicitly declare `icons.icon` alongside `icons.apple`, pointing at the existing `public/icon-192.png`/`icon-512.png` (already used by the web manifest).

## Test plan
- [x] Ran `bun run dev` and confirmed `curl localhost:3000/` now includes `<link rel="icon" ...>` tags for both sizes
- [ ] Visually confirm favicon renders in browser tab after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HGjUSv9RigfnFtuzMPXfpk