### PR TITLE
Fix metrics that never reached Grafana

### DIFF
--- a/apps/backend/src/main/kotlin/uk/co/suskins/pubgolf/service/GameMetrics.kt
+++ b/apps/backend/src/main/kotlin/uk/co/suskins/pubgolf/service/GameMetrics.kt
@@ -1,30 +1,54 @@
 package uk.co.suskins.pubgolf.service
 
+import io.micrometer.core.instrument.Counter
 import io.micrometer.core.instrument.MeterRegistry
 import org.springframework.stereotype.Service
+import uk.co.suskins.pubgolf.models.GameConstants
 import uk.co.suskins.pubgolf.models.Hole
 
 @Service
 class GameMetrics(
     private val registry: MeterRegistry,
 ) {
+    private val gameStartedCounter = registry.counter(GAME_STARTED)
+    private val playerJoinedCounter = registry.counter(PLAYER_JOINED)
+    private val randomiseUsedCounter = registry.counter(GAME_RANDOMISE)
+    private val gameCompletedCounter = registry.counter(GAME_COMPLETED)
+    private val scoreSubmittedCounters =
+        (1..GameConstants.MAX_HOLES).associateWith(::scoreSubmittedCounter)
+
     fun gameCreated() {
-        registry.counter("pubgolf.game.created").increment()
+        gameStartedCounter.increment()
     }
 
     fun playerJoined() {
-        registry.counter("pubgolf.player.joined").increment()
+        playerJoinedCounter.increment()
     }
 
     fun scoreSubmitted(hole: Hole) {
-        registry.counter("pubgolf.score.submitted", "hole", hole.value.toString()).increment()
+        scoreSubmittedCounters
+            .getOrElse(hole.value) { scoreSubmittedCounter(hole.value) }
+            .increment()
     }
 
     fun randomiseUsed() {
-        registry.counter("pubgolf.game.randomise").increment()
+        randomiseUsedCounter.increment()
     }
 
     fun gameCompleted() {
-        registry.counter("pubgolf.game.completed").increment()
+        gameCompletedCounter.increment()
+    }
+
+    private fun scoreSubmittedCounter(hole: Int): Counter = registry.counter(SCORE_SUBMITTED, "hole", hole.toString())
+
+    companion object {
+        const val GAME_STARTED = "pubgolf.game.started"
+        const val PLAYER_JOINED = "pubgolf.player.joined"
+        const val SCORE_SUBMITTED = "pubgolf.score.submitted"
+        const val GAME_RANDOMISE = "pubgolf.game.randomise"
+        const val GAME_COMPLETED = "pubgolf.game.completed"
+
+        val ALL_METRIC_NAMES =
+            listOf(GAME_STARTED, PLAYER_JOINED, SCORE_SUBMITTED, GAME_RANDOMISE, GAME_COMPLETED)
     }
 }

--- a/apps/backend/src/main/resources/application.yml
+++ b/apps/backend/src/main/resources/application.yml
@@ -37,3 +37,9 @@ management:
   endpoint:
     prometheus:
       enabled: true
+  metrics:
+    distribution:
+      percentiles-histogram:
+        http.server.requests: true
+      maximum-expected-value:
+        http.server.requests: 5s

--- a/apps/backend/src/test/kotlin/uk/co/suskins/pubgolf/events/GameEventDeliveryTest.kt
+++ b/apps/backend/src/test/kotlin/uk/co/suskins/pubgolf/events/GameEventDeliveryTest.kt
@@ -10,6 +10,7 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Primary
 import org.springframework.test.context.ActiveProfiles
 import uk.co.suskins.pubgolf.models.PlayerName
+import uk.co.suskins.pubgolf.service.GameMetrics
 import uk.co.suskins.pubgolf.service.GameService
 import uk.co.suskins.pubgolf.service.GameStateBroadcasterFake
 import kotlin.test.assertTrue
@@ -53,16 +54,16 @@ class GameEventDeliveryTest {
 
     @Test
     fun `game lifecycle events reach the metrics listener`() {
-        val createdBefore = meterRegistry.find("pubgolf.game.created").counter()?.count() ?: 0.0
-        val joinedBefore = meterRegistry.find("pubgolf.player.joined").counter()?.count() ?: 0.0
+        val startedBefore = meterRegistry.find(GameMetrics.GAME_STARTED).counter()?.count() ?: 0.0
+        val joinedBefore = meterRegistry.find(GameMetrics.PLAYER_JOINED).counter()?.count() ?: 0.0
 
         val game = gameService.createGame(PlayerName("MetricsHost")).valueOrNull()!!
         gameService.joinGame(game.code, PlayerName("MetricsGuest"))
 
-        val createdAfter = meterRegistry.find("pubgolf.game.created").counter()?.count() ?: 0.0
-        val joinedAfter = meterRegistry.find("pubgolf.player.joined").counter()?.count() ?: 0.0
+        val startedAfter = meterRegistry.find(GameMetrics.GAME_STARTED).counter()?.count() ?: 0.0
+        val joinedAfter = meterRegistry.find(GameMetrics.PLAYER_JOINED).counter()?.count() ?: 0.0
 
-        assertTrue(createdAfter > createdBefore, "Expected pubgolf.game.created to increment")
-        assertTrue(joinedAfter > joinedBefore, "Expected pubgolf.player.joined to increment")
+        assertTrue(startedAfter > startedBefore, "Expected ${GameMetrics.GAME_STARTED} to increment")
+        assertTrue(joinedAfter > joinedBefore, "Expected ${GameMetrics.PLAYER_JOINED} to increment")
     }
 }

--- a/apps/backend/src/test/kotlin/uk/co/suskins/pubgolf/service/GameMetricsTest.kt
+++ b/apps/backend/src/test/kotlin/uk/co/suskins/pubgolf/service/GameMetricsTest.kt
@@ -3,7 +3,9 @@ package uk.co.suskins.pubgolf.service
 import com.natpryce.hamkrest.assertion.assertThat
 import com.natpryce.hamkrest.equalTo
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import io.prometheus.metrics.model.snapshots.PrometheusNaming
 import org.junit.jupiter.api.Test
+import uk.co.suskins.pubgolf.models.GameConstants
 import uk.co.suskins.pubgolf.models.Hole
 
 class GameMetricsTest {
@@ -11,25 +13,24 @@ class GameMetricsTest {
     private val gameMetrics = GameMetrics(registry)
 
     @Test
-    fun `Can increment game created counter`() {
+    fun `Can increment game started counter`() {
         gameMetrics.gameCreated()
 
-        assertThat(registry.get("pubgolf.game.created").counter().count(), equalTo(1.0))
+        assertThat(registry.get(GameMetrics.GAME_STARTED).counter().count(), equalTo(1.0))
     }
 
     @Test
     fun `Can increment player joined counter`() {
         gameMetrics.playerJoined()
 
-        assertThat(registry.get("pubgolf.player.joined").counter().count(), equalTo(1.0))
+        assertThat(registry.get(GameMetrics.PLAYER_JOINED).counter().count(), equalTo(1.0))
     }
 
     @Test
     fun `Can increment score submitted counter`() {
         gameMetrics.scoreSubmitted(Hole(1))
 
-        val metric = registry.get("pubgolf.score.submitted")
-        assertThat(metric.counter().count(), equalTo(1.0))
+        val metric = registry.get(GameMetrics.SCORE_SUBMITTED)
         assertThat(metric.tags("hole", "1").counter().count(), equalTo(1.0))
     }
 
@@ -37,6 +38,54 @@ class GameMetricsTest {
     fun `Can increment randomise counter`() {
         gameMetrics.randomiseUsed()
 
-        assertThat(registry.get("pubgolf.game.randomise").counter().count(), equalTo(1.0))
+        assertThat(registry.get(GameMetrics.GAME_RANDOMISE).counter().count(), equalTo(1.0))
+    }
+
+    @Test
+    fun `Can increment game completed counter`() {
+        gameMetrics.gameCompleted()
+
+        assertThat(registry.get(GameMetrics.GAME_COMPLETED).counter().count(), equalTo(1.0))
+    }
+
+    @Test
+    fun `Counters are registered at zero before anything happens`() {
+        GameMetrics.ALL_METRIC_NAMES.forEach { name ->
+            assertThat(registry.get(name).counter().count(), equalTo(0.0))
+        }
+    }
+
+    @Test
+    fun `Every hole has a score submitted counter registered at zero`() {
+        (1..GameConstants.MAX_HOLES).forEach { hole ->
+            val counter = registry.get(GameMetrics.SCORE_SUBMITTED).tags("hole", hole.toString()).counter()
+            assertThat(counter.count(), equalTo(0.0))
+        }
+    }
+
+    @Test
+    fun `Scores on an unexpected hole are still counted`() {
+        val unexpectedHole = GameConstants.MAX_HOLES + 1
+
+        gameMetrics.scoreSubmitted(Hole(unexpectedHole))
+
+        val counter =
+            registry
+                .get(GameMetrics.SCORE_SUBMITTED)
+                .tags("hole", unexpectedHole.toString())
+                .counter()
+        assertThat(counter.count(), equalTo(1.0))
+    }
+
+    @Test
+    fun `Metric names survive Prometheus naming without being rewritten`() {
+        GameMetrics.ALL_METRIC_NAMES.forEach { name ->
+            assertThat(PrometheusNaming.sanitizeMetricName(name), equalTo(name))
+        }
+    }
+
+    @Test
+    fun `Reserved Prometheus suffixes are silently stripped from metric names`() {
+        assertThat(PrometheusNaming.sanitizeMetricName("pubgolf.game.created"), equalTo("pubgolf.game"))
     }
 }


### PR DESCRIPTION
Most of the pubgolf Grafana dashboard has been showing **No Data**. Investigating the live endpoint on the docker host turned up three separate defects.

## 1. Latency histograms were never emitted

Micrometer publishes `http_server_requests_seconds` as a **summary** by default — `_count`/`_sum`/`_max` only, no buckets. The live endpoint had **zero** `_bucket` series, so every `histogram_quantile()` panel and the `pubgolf-latency-p95` alert resolved to nothing. The alert has never been able to fire.

Enabled `percentiles-histogram` for `http.server.requests`, with `maximum-expected-value: 5s` to keep the bucket count reasonable.

## 2. `pubgolf.game.created` was silently renamed to `pubgolf_game_total`

This one is subtle. `_created` is a **reserved OpenMetrics suffix**. In `prometheus-metrics-model` (pulled in by Spring Boot 3.5.3), `RESERVED_METRIC_NAME_SUFFIXES` contains `_total`, `_created`, `_bucket`, `_info`, and `sanitizeMetricName` strips them in a loop:

```
pubgolf.game.created → strip "_created" → pubgolf.game → +"_total" → pubgolf_game_total
```

Confirmed directly against the library:

```
pubgolf.game.created    ->  pubgolf.game
pubgolf.game.started    ->  pubgolf.game.started
pubgolf.player.joined   ->  pubgolf.player.joined
```

So dashboards querying `pubgolf_game_created_total` could never have matched anything.

Renamed the metric to `pubgolf.game.started`, and added a test asserting `sanitizeMetricName` leaves every name in `ALL_METRIC_NAMES` untouched — so this class of bug can't come back silently. A second test pins the stripping behaviour itself as documentation.

## 3. Counters only existed after their first increment

Micrometer registers counters lazily. A freshly restarted instance exposed *only* `pubgolf_game_total` — `player_joined`, `score_submitted`, `randomise` and `completed` were absent entirely, so panels read "No Data" instead of `0`.

All counters are now registered eagerly at construction, including one `score.submitted` series per hole (`1..MAX_HOLES`). Scores on an unexpected hole still register on demand rather than being dropped.

## Verification

Booted locally and hit `/actuator/prometheus`:

```
# TYPE http_server_requests_seconds histogram     ← was "summary"
58 × http_server_requests_seconds_bucket series

pubgolf_game_started_total 0.0                    ← was pubgolf_game_total
pubgolf_game_completed_total 0.0
pubgolf_game_randomise_total 0.0
pubgolf_player_joined_total 0.0
pubgolf_score_submitted_total{hole="1".."9"} 0.0
```

Full backend suite + `ktlintCheck` pass.

## Follow-up (not in this PR)

- The deployed dashboard in the homelab repo (`config/grafana/dashboards/Apps/pubgolf-backend.json`) still queries `pubgolf_game_created_total` and needs updating to `pubgolf_game_started_total`, as does the `pubgolf-latency-p95` alert rule.
- `grafana/dashboards/pubgolf.json` in *this* repo queries the mangled `pubgolf_game_total` and isn't provisioned anywhere — Ansible only deploys from the homelab repo. Worth deleting or reconciling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K9E28ZEnT6ak9r7Wbrba7b