### PR TITLE
Show the default course on the rules page outside a game

### DIFF
--- a/apps/frontend/app/game/page.tsx
+++ b/apps/frontend/app/game/page.tsx
@@ -17,6 +17,7 @@ import { EventNotificationOverlay } from '@/components/EventNotificationOverlay'
 import { EventBanner } from '@/components/EventBanner';
 import { Player, GameState } from '@/lib/types';
 import { firstUnplayedHole, playerParRelative } from '@/lib/scoring';
+import { GAME_RULES_HREF } from '@/lib/constants';
 import { ErrorMessage } from '@/components/ui/ErrorMessage';
 
 export default function GamePage() {
@@ -190,7 +191,7 @@ export default function GamePage() {
           </div>
           <div className="flex items-center gap-2">
             <Link
-              href="/how-to-play"
+              href={GAME_RULES_HREF}
               className="flex items-center gap-1.5 h-11 px-3.5 rounded-[10px] bg-[var(--color-surface-inset)] border border-[var(--color-border-subtle)] hover:bg-[var(--color-surface-hover)] transition-colors shrink-0"
             >
               <svg width="15" height="15" viewBox="0 0 24 24" fill="none" aria-hidden="true">

--- a/apps/frontend/app/how-to-play/BackButton.tsx
+++ b/apps/frontend/app/how-to-play/BackButton.tsx
@@ -1,15 +1,26 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
+import Link from 'next/link';
 
-export function BackButton() {
+const LINK_CLASSES =
+  'text-[13px] text-[var(--color-text-secondary)] hover:text-[var(--color-text)] transition-colors';
+
+export function BackButton({ fromGame }: { fromGame: boolean }) {
   const router = useRouter();
 
+  // Reached from anywhere but a game — the home page, a search result — there is
+  // no scoreboard behind us, so going back has to mean the home page.
+  if (!fromGame) {
+    return (
+      <Link href="/" className={LINK_CLASSES}>
+        ← Back to Home
+      </Link>
+    );
+  }
+
   return (
-    <button
-      onClick={() => router.back()}
-      className="text-[13px] text-[var(--color-text-secondary)] hover:text-[var(--color-text)] transition-colors"
-    >
+    <button onClick={() => router.back()} className={LINK_CLASSES}>
       ← Back to Scoreboard
     </button>
   );

--- a/apps/frontend/app/how-to-play/page.test.tsx
+++ b/apps/frontend/app/how-to-play/page.test.tsx
@@ -45,8 +45,17 @@ mock.module('next/navigation', () => ({
   }),
 }));
 
+// The page reads the entry point off the URL rather than useSearchParams, so
+// the route keeps prerendering statically for search engines.
+function visit(search: string) {
+  (window as unknown as { happyDOM: { setURL: (url: string) => void } }).happyDOM.setURL(
+    `http://localhost:3000/how-to-play${search}`
+  );
+}
+
 describe('HowToPlayPage', () => {
   beforeEach(() => {
+    visit('');
     mockGetPenaltyOptions.mockImplementation(() => Promise.resolve({
       penalties: [
         { type: 'SKIP', name: 'Skip', points: 5 },
@@ -170,6 +179,7 @@ describe('HowToPlayPage', () => {
     });
 
     test('should drop the choice when the course has one route', async () => {
+      visit('?from=game');
       mockGetGameCode.mockImplementation(() => 'ACE007');
       render(<HowToPlayPage />);
 
@@ -194,7 +204,8 @@ describe('HowToPlayPage', () => {
   });
 
   describe('game course', () => {
-    test("should render the game's own course when in a game", async () => {
+    test("should render the game's own course when opened from the game", async () => {
+      visit('?from=game');
       mockGetGameCode.mockImplementation(() => 'ACE007');
       render(<HowToPlayPage />);
 
@@ -206,12 +217,46 @@ describe('HowToPlayPage', () => {
     });
 
     test('should fall back to the default course when not in a game', async () => {
+      visit('?from=game');
       render(<HowToPlayPage />);
 
       await waitFor(() => {
         expect(screen.getByText('Route A')).toBeInTheDocument();
       });
       expect(mockGetGameState).not.toHaveBeenCalled();
+    });
+
+    test('should show the default course when opened outside a game', async () => {
+      mockGetGameCode.mockImplementation(() => 'ACE007');
+      render(<HowToPlayPage />);
+
+      await waitFor(() => {
+        expect(screen.getByText('Route A')).toBeInTheDocument();
+      });
+      expect(mockGetGameState).not.toHaveBeenCalled();
+      expect(mockGetRoutes).toHaveBeenCalled();
+    });
+  });
+
+  describe('back link', () => {
+    test('should go home when opened outside a game', () => {
+      mockGetGameCode.mockImplementation(() => 'ACE007');
+      render(<HowToPlayPage />);
+
+      const back = screen.getByRole('link', { name: /back to home/i });
+      expect(back).toHaveAttribute('href', '/');
+      expect(screen.queryByText(/back to scoreboard/i)).not.toBeInTheDocument();
+    });
+
+    test('should go back to the scoreboard when opened from the game', async () => {
+      visit('?from=game');
+      mockGetGameCode.mockImplementation(() => 'ACE007');
+      render(<HowToPlayPage />);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /back to scoreboard/i })).toBeInTheDocument();
+      });
+      expect(screen.queryByText(/back to home/i)).not.toBeInTheDocument();
     });
   });
 

--- a/apps/frontend/app/how-to-play/page.tsx
+++ b/apps/frontend/app/how-to-play/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useEffect, useState } from 'react';
-import { buildRules } from '@/lib/constants';
+import { useEffect, useState, useSyncExternalStore } from 'react';
+import { buildRules, isFromGame } from '@/lib/constants';
 import { getPenaltyOptions, getRoutes, getGameState, PenaltyOption } from '@/lib/api';
 import { PENALTY_EMOJI_MAP, PenaltyType, RouteHole } from '@/lib/types';
 import { useLocalStorage } from '@/hooks/useLocalStorage';
@@ -67,6 +67,24 @@ function RoutesTableSkeleton() {
   );
 }
 
+// The query string is fixed for the life of the page, so there is nothing to
+// subscribe to.
+const noSubscription = () => () => {};
+
+/**
+ * Whether the page was opened from a game. The marker lives in the URL, but
+ * reading it with useSearchParams would opt the whole page out of static
+ * prerendering — and these rules are a landing page for search engines. The
+ * server snapshot keeps the prerendered markup honest instead.
+ */
+function useFromGame(): boolean {
+  return useSyncExternalStore(
+    noSubscription,
+    () => isFromGame(window.location.search),
+    () => false
+  );
+}
+
 export default function HowToPlayPage() {
   const [penalties, setPenalties] = useState<PenaltyOption[]>([]);
   const [holes, setHoles] = useState<RouteHole[]>([]);
@@ -74,6 +92,7 @@ export default function HowToPlayPage() {
   const [isRoutesLoading, setIsRoutesLoading] = useState(true);
   const [penaltiesError, setPenaltiesError] = useState(false);
   const [routesError, setRoutesError] = useState(false);
+  const fromGame = useFromGame();
   const { getGameCode } = useLocalStorage();
 
   // Route names come from the course itself, so the rules name the host's
@@ -86,9 +105,13 @@ export default function HowToPlayPage() {
       .catch(() => setPenaltiesError(true))
       .finally(() => setIsPenaltiesLoading(false));
 
-    // In a game, show that game's course (the host can have customised it);
-    // otherwise fall back to the default course.
-    const gameCode = getGameCode();
+    // Opened from a game, show that game's course — the host can have
+    // customised it. Everywhere else, the home page or a search result, these
+    // are the general rules, so they show the default course even when this
+    // browser is still in a game. Read here rather than from the render above,
+    // which reports the server's snapshot until hydration finishes and would
+    // fetch the default course before switching.
+    const gameCode = isFromGame(window.location.search) ? getGameCode() : null;
     const course = gameCode
       ? getGameState(gameCode).then((state) => state.holes)
       : getRoutes().then((response) => response.holes);
@@ -103,7 +126,7 @@ export default function HowToPlayPage() {
     <main className="p-5 py-6">
       <div className="max-w-md mx-auto space-y-6">
         <div>
-          <BackButton />
+          <BackButton fromGame={fromGame} />
         </div>
         <div className="text-center">
           <Typography variant="display" className="mb-3 text-4xl">

--- a/apps/frontend/app/page.tsx
+++ b/apps/frontend/app/page.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { GolfBallLogo } from '@/components/GolfBallLogo';
 import { HomeGameEntry } from '@/components/HomeGameEntry';
 import { homeStructuredDataJson } from './homeStructuredData';
+import { RULES_HREF } from '@/lib/constants';
 
 export const metadata: Metadata = {
   alternates: {
@@ -50,7 +51,7 @@ export default function HomePage() {
 
         <div className="text-center">
           <Link
-            href="/how-to-play"
+            href={RULES_HREF}
             className="text-[13px] text-[var(--color-text-muted)] border-b border-dashed border-[var(--color-border-subtle)] pb-0.5 hover:text-[var(--color-text-secondary)] transition-colors"
           >
             First time? Learn the rules
@@ -89,7 +90,7 @@ export default function HomePage() {
               rule-breakers, and spin the randomiser when someone needs a surprise. Perfect
               for birthdays, stag and hen dos, or any night out.{' '}
               <Link
-                href="/how-to-play"
+                href={RULES_HREF}
                 className="text-[var(--color-text-muted)] underline decoration-dashed underline-offset-4 hover:text-[var(--color-text-secondary)] transition-colors"
               >
                 Read the full pub golf rules

--- a/apps/frontend/lib/constants.test.ts
+++ b/apps/frontend/lib/constants.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect } from 'bun:test';
-import { RULES, buildRules, routeRule } from './constants';
+import { RULES, buildRules, routeRule, isFromGame, GAME_RULES_HREF, RULES_HREF } from './constants';
 
 describe('RULES', () => {
   test('should export an array of 4 rules', () => {
@@ -76,5 +76,25 @@ describe('buildRules', () => {
     expect(rules[0]).toBe(RULES[0]);
     expect(rules[2]).toBe(RULES[2]);
     expect(rules[3]).toBe(RULES[3]);
+  });
+});
+
+describe('isFromGame', () => {
+  test('should recognise the in-game rules link', () => {
+    expect(isFromGame(new URL(`http://localhost${GAME_RULES_HREF}`).search)).toBe(true);
+  });
+
+  test('should reject the plain rules link', () => {
+    expect(isFromGame(new URL(`http://localhost${RULES_HREF}`).search)).toBe(false);
+    expect(isFromGame('')).toBe(false);
+  });
+
+  test('should reject other origins', () => {
+    expect(isFromGame('?from=home')).toBe(false);
+    expect(isFromGame('?game=true')).toBe(false);
+  });
+
+  test('should ignore unrelated query params', () => {
+    expect(isFromGame('?utm_source=x&from=game')).toBe(true);
   });
 });

--- a/apps/frontend/lib/constants.ts
+++ b/apps/frontend/lib/constants.ts
@@ -34,3 +34,18 @@ export function buildRules(routeNames: string[] = []): string[] {
 
 /** Generic rules, used before a course has loaded. */
 export const RULES = buildRules();
+
+/** The rules page, showing the default course everyone can read about. */
+export const RULES_HREF = '/how-to-play';
+
+/**
+ * The rules page as opened from inside a game. The marker is what unlocks the
+ * host's customised course: without it the page always shows the default one,
+ * so a stored game never bleeds into the rules read from the home page.
+ */
+export const GAME_RULES_HREF = `${RULES_HREF}?from=game`;
+
+/** Whether a location's query string came from the in-game rules link. */
+export function isFromGame(search: string): boolean {
+  return new URLSearchParams(search).get('from') === 'game';
+}

--- a/e2e/tests/host-course.spec.ts
+++ b/e2e/tests/host-course.spec.ts
@@ -46,9 +46,18 @@ test.describe('Host Course Editing', () => {
 
     await expect(page.getByText('Saved — all players updated')).toBeVisible();
 
-    // The rules page reads the game's course, not the global default.
-    await page.goto('/how-to-play');
+    // Opened from the game, the rules page reads that game's course rather
+    // than the global default.
+    await page.goto('/how-to-play?from=game');
     await expect(page.getByText('Espresso Martini')).toBeVisible();
+
+    // Opened from the home page it is the generic rules, so the default course
+    // shows even though this browser is still in a game.
+    await page.goto('/');
+    await page.getByRole('link', { name: /learn the rules/i }).click();
+    await expect(page.getByRole('heading', { name: /The Course/i })).toBeVisible();
+    await expect(page.getByText('Tequila')).toBeVisible();
+    await expect(page.getByText('Espresso Martini')).toHaveCount(0);
 
     // Par drives the log-score screen too.
     await page.goto('/submit-score');
@@ -105,7 +114,7 @@ test.describe('Host Course Editing', () => {
 
     await expect(page.getByText('Saved — all players updated')).toBeVisible();
 
-    await page.goto('/how-to-play');
+    await page.goto('/how-to-play?from=game');
     await expect(page.getByRole('columnheader', { name: 'Ale Trail' })).toBeVisible();
   });
 
@@ -139,7 +148,7 @@ test.describe('Host Course Editing', () => {
     await page.getByRole('button', { name: 'SAVE COURSE' }).click();
     await expect(page.getByText('Saved — all players updated')).toBeVisible();
 
-    await page.goto('/how-to-play');
+    await page.goto('/how-to-play?from=game');
     await expect(page.getByRole('columnheader', { name: 'Wine Walk' })).toBeVisible();
   });
 

--- a/e2e/tests/routes.spec.ts
+++ b/e2e/tests/routes.spec.ts
@@ -36,4 +36,18 @@ test.describe('Routes on How To Play', () => {
     await expect(page.getByText('VK')).toBeVisible();
     await expect(page.getByText('Smirnoff Ice')).toBeVisible();
   });
+
+  test('back link returns home when not opened from a game', async ({ page }) => {
+    await page.goto('/how-to-play');
+
+    await page.getByRole('link', { name: /back to home/i }).click();
+
+    await expect(page).toHaveURL(/\/$/);
+  });
+
+  test('back link returns to the scoreboard when opened from a game', async ({ page }) => {
+    await page.goto('/how-to-play?from=game');
+
+    await expect(page.getByRole('button', { name: /back to scoreboard/i })).toBeVisible();
+  });
 });


### PR DESCRIPTION
## What

The rules page read the stored game code straight from `localStorage`, so anyone who had joined a game saw that host's customised course even when they opened the rules from the home page or a search result. The back link had the same problem in reverse: it always said "Back to Scoreboard", a dead end when there is no scoreboard behind it.

The in-game rules link now carries a `?from=game` marker, and that marker is what unlocks the game's course and the scoreboard back link:

| Opened from | Course shown | Back link |
| --- | --- | --- |
| Game page | That game's course (custom if the host edited it) | ← Back to Scoreboard (`router.back()`) |
| Home page, search result, direct hit | Default course | ← Back to Home (`/`) |

## How

- `lib/constants.ts` — `RULES_HREF`, `GAME_RULES_HREF` and `isFromGame()` so both ends of the link agree on the marker.
- `app/game/page.tsx` — the Rules button links to `GAME_RULES_HREF`; the home page links stay on the plain rules URL.
- `app/how-to-play/page.tsx` — the course request only reaches for the stored game code when the marker is present.
- `app/how-to-play/BackButton.tsx` — renders a `Link` home unless it came from a game.

The marker is read from `window.location` rather than `useSearchParams`, which would opt this route out of static prerendering — it is a landing page for search, with a canonical URL, sitemap entry and FAQ JSON-LD. `useSyncExternalStore` keeps the prerendered markup and hydration in agreement, and the course fetch reads the URL inside its effect so a hard load never requests the default course before switching to the game's.

## Testing

- `bun test` — 480 pass, including new cases for the two entry points and the back link, and unit tests for `isFromGame`.
- `bun run lint`, `bun run build` — clean; `/how-to-play` still builds as static (`○`), and the prerendered HTML keeps the rules copy and FAQ.
- Drove the production build in Chromium with a game stored in `localStorage`: `/how-to-play` shows "Back to Home" and requests only `/config/routes`; `/how-to-play?from=game` shows "Back to Scoreboard" and requests only `/games/{code}`.
- e2e specs updated: the host-course tests now open the rules with the marker, plus a new assertion that the default course shows when the same browser reaches the rules from the home page.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LVxjKEvU5BhZVseaDJXybK)_